### PR TITLE
Update booking timestamps to use timestamptz and ISO UTC serialization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # App
 NODE_ENV=development
 PORT=3000
+TZ=UTC
 
 # Auth
 JWT_SECRET=replace-with-a-strong-secret

--- a/ormconfig.js
+++ b/ormconfig.js
@@ -7,7 +7,7 @@ module.exports = {
   username: process.env.DATABASE_USER,
   password: process.env.DATABASE_PASSWORD,
   database: process.env.DATABASE_NAME,
-  synchronize: true,
+  synchronize: false,
   logging: false,
   entities: [
     'src/api/**/*.entity.ts'

--- a/src/api/booking/entities/booking.entity.ts
+++ b/src/api/booking/entities/booking.entity.ts
@@ -10,10 +10,10 @@ export class Booking {
   @Column()
   resourceId!: string;
 
-  @Column()
+  @Column({ type: 'timestamptz' })
   startTime!: Date;
 
-  @Column()
+  @Column({ type: 'timestamptz' })
   endTime!: Date;
 
   @Column()

--- a/src/api/booking/services/booking.service.date-range.spec.ts
+++ b/src/api/booking/services/booking.service.date-range.spec.ts
@@ -35,10 +35,10 @@ describe('BookingService date-range filtering', () => {
     await service.findAll(1, 20, 'startTime', 'ASC', '2026-02-27', '2026-05-27');
 
     expect(queryBuilder.andWhere).toHaveBeenCalledWith('booking.startTime >= :startDate', {
-      startDate: '2026-02-27T00:00:00.000Z',
+      startDate: new Date('2026-02-27T00:00:00.000Z'),
     });
     expect(queryBuilder.andWhere).toHaveBeenCalledWith('booking.startTime <= :endDate', {
-      endDate: '2026-05-27T23:59:59.999Z',
+      endDate: new Date('2026-05-27T23:59:59.999Z'),
     });
   });
 

--- a/src/api/booking/services/booking.service.spec.ts
+++ b/src/api/booking/services/booking.service.spec.ts
@@ -74,7 +74,13 @@ describe('BookingService', () => {
       );
 
       expect(result.message).toBe('Booking created successfully');
-      expect(result.booking).toEqual(createdBooking);
+      expect(result.booking).toMatchObject({
+        id: 'booking-1',
+        startTime: '2026-06-10T12:00:00.000Z',
+        endTime: '2026-06-10T15:00:00.000Z',
+      });
+      expect(result.booking.startTime).toMatch(/Z$/);
+      expect(result.booking.endTime).toMatch(/Z$/);
       expect(bookingRepository.create).toHaveBeenCalledWith(
         expect.objectContaining({
           bookedOnBehalf: 'Family Event',
@@ -106,6 +112,8 @@ describe('BookingService', () => {
         id: 'booking-1',
         user: { id: 'user-1' },
         resource: { id: 'resource-1' },
+        startTime: dto.startTime,
+        endTime: dto.endTime,
       } as unknown as Booking;
 
       jest.spyOn(service, 'checkAvailability').mockResolvedValue({ available: true, message: 'Available' });
@@ -114,9 +122,16 @@ describe('BookingService', () => {
       jest.spyOn(bookingRepository, 'create').mockReturnValue(createdBooking);
       jest.spyOn(bookingRepository, 'save').mockResolvedValue(createdBooking);
 
-      await expect(service.create(dto, 'user-1', UserRole.RESIDENT)).resolves.toEqual({
+      const result = await service.create(dto, 'user-1', UserRole.RESIDENT);
+      expect(result).toMatchObject({
         message: 'Booking created successfully',
-        booking: createdBooking,
+        booking: {
+          id: 'booking-1',
+          user: { id: 'user-1' },
+          resource: { id: 'resource-1' },
+          startTime: dto.startTime.toISOString(),
+          endTime: dto.endTime.toISOString(),
+        },
       });
     });
 
@@ -147,7 +162,7 @@ describe('BookingService', () => {
   });
 
   describe('findAll', () => {
-    it('applies date range filters and maps paginated response', async () => {
+    it('applies date range filters and maps paginated response as ISO UTC', async () => {
       const bookings: Booking[] = [
         {
           id: 'booking-1',
@@ -188,8 +203,8 @@ describe('BookingService', () => {
             resourceId: 'resource-1',
             resourceName: 'Party Hall',
             resourceType: 'hall',
-            startTime: new Date('2026-06-10T12:00:00.000Z'),
-            endTime: new Date('2026-06-10T15:00:00.000Z'),
+            startTime: '2026-06-10T12:00:00.000Z',
+            endTime: '2026-06-10T15:00:00.000Z',
             userId: 'user-1',
             userApartment: '101',
             userBlock: 1,
@@ -205,7 +220,7 @@ describe('BookingService', () => {
   });
 
   describe('findByUser', () => {
-    it('returns paginated user bookings', async () => {
+    it('returns paginated user bookings serialized as ISO UTC', async () => {
       const bookings = [
         {
           id: 'booking-1',
@@ -229,8 +244,8 @@ describe('BookingService', () => {
             resourceId: 'resource-1',
             resourceName: 'Party Hall',
             resourceType: 'hall',
-            startTime: new Date('2026-06-10T12:00:00.000Z'),
-            endTime: new Date('2026-06-10T15:00:00.000Z'),
+            startTime: '2026-06-10T12:00:00.000Z',
+            endTime: '2026-06-10T15:00:00.000Z',
             userId: 'user-1',
             userApartment: '101',
             userBlock: 1,
@@ -242,6 +257,26 @@ describe('BookingService', () => {
         page: 1,
         lastPage: 1,
       });
+      expect(result.data[0].startTime).toMatch(/Z$/);
+      expect(result.data[0].endTime).toMatch(/Z$/);
+    });
+
+    it('keeps UTC instant for a Sao Paulo 08:00 booking and serializes as 11:00Z', async () => {
+      const bookings = [
+        {
+          id: 'booking-2',
+          startTime: new Date('2026-06-10T11:00:00.000Z'),
+          endTime: new Date('2026-06-10T12:00:00.000Z'),
+          needTablesAndChairs: false,
+          user: { id: 'user-1', apartment: '101', block: 1 },
+          resource: { id: 'resource-1', name: 'Court 1', type: 'tennis' },
+        },
+      ];
+
+      jest.spyOn(bookingRepository, 'findAndCount').mockResolvedValue([bookings as Booking[], 1]);
+
+      const result = await service.findByUser('user-1', 1, 10, 'startTime', 'ASC');
+      expect(result.data[0].startTime).toBe('2026-06-10T11:00:00.000Z');
     });
   });
 
@@ -494,6 +529,35 @@ describe('BookingService', () => {
         ),
       ).rejects.toThrow(ForbiddenException);
     });
+
+    it('serializes updated booking timestamps as ISO UTC', async () => {
+      const booking = {
+        id: 'booking-1',
+        user: { id: 'owner-1' },
+        resource: { id: 'resource-1' },
+        startTime: new Date('2026-06-10T10:00:00.000Z'),
+        endTime: new Date('2026-06-10T11:00:00.000Z'),
+        needTablesAndChairs: false,
+      } as unknown as Booking;
+
+      jest.spyOn(bookingRepository, 'findOne').mockResolvedValue(booking);
+      jest.spyOn(resourceService, 'findOne').mockResolvedValue({ id: 'resource-1', type: 'hall' } as Resource);
+      jest.spyOn(service, 'checkAvailability').mockResolvedValue({ available: true, message: 'Available' });
+      jest.spyOn(bookingRepository, 'save').mockResolvedValue(booking);
+
+      const result = await service.update(
+        'booking-1',
+        {
+          startTime: new Date('2026-06-11T10:00:00.000Z'),
+          endTime: new Date('2026-06-11T11:00:00.000Z'),
+        },
+        'owner-1',
+        UserRole.RESIDENT,
+      );
+
+      expect(result.booking.startTime).toBe('2026-06-11T10:00:00.000Z');
+      expect(result.booking.endTime).toBe('2026-06-11T11:00:00.000Z');
+    });
   });
 
   describe('getReservedTimes', () => {
@@ -527,8 +591,8 @@ describe('BookingService', () => {
       expect(result).toEqual({
         reservedTimes: [
           {
-            startTime: new Date('2026-03-03T22:00:00.000Z'),
-            endTime: new Date('2026-03-03T23:00:00.000Z'),
+            startTime: '2026-03-03T22:00:00.000Z',
+            endTime: '2026-03-03T23:00:00.000Z',
           },
         ],
       });

--- a/src/api/booking/services/booking.service.ts
+++ b/src/api/booking/services/booking.service.ts
@@ -82,7 +82,7 @@ export class BookingService {
     this.logger.log(`Booking created successfully: ${booking.id}`);
     this.logger.log(`Booking created successfully: ${booking.id}, user: ${user.id}, resource: ${resource.id}, start time: ${startTime}, end time: ${endTime}, needTablesAndChairs: ${needTablesAndChairs}`);
 
-    return { message: 'Booking created successfully', booking };
+    return { message: 'Booking created successfully', booking: this.serializeBookingTimestampFields(booking) };
   }
 
   async update(bookingId: string, updateBookingDto: Partial<CreateBookingDto>, userId: string, userRole: string) {
@@ -145,7 +145,7 @@ export class BookingService {
 
     await this.bookingRepository.save(booking);
     this.logger.log(`Booking updated successfully: ${booking.id}`);
-    return { message: 'Booking updated successfully', booking };
+    return { message: 'Booking updated successfully', booking: this.serializeBookingTimestampFields(booking) };
   }
 
   async checkAvailability(
@@ -257,8 +257,8 @@ export class BookingService {
         resourceId: booking.resource.id,
         resourceName: booking.resource.name,
         resourceType: booking.resource.type,
-        startTime: booking.startTime,
-        endTime: booking.endTime,
+        startTime: this.toUtcIsoString(booking.startTime),
+        endTime: this.toUtcIsoString(booking.endTime),
         userId: booking.user.id,
         userApartment: booking.user.apartment,
         userBlock: booking.user.block,
@@ -324,8 +324,8 @@ export class BookingService {
         resourceId: booking.resource.id,
         resourceName: booking.resource.name,
         resourceType: booking.resource.type,
-        startTime: booking.startTime,
-        endTime: booking.endTime,
+        startTime: this.toUtcIsoString(booking.startTime),
+        endTime: this.toUtcIsoString(booking.endTime),
         userId: booking.user.id,
         userApartment: booking.user.apartment,
         userBlock: booking.user.block,
@@ -400,8 +400,8 @@ export class BookingService {
       .getMany();
 
     const reservedTimes = bookings.map(booking => ({
-      startTime: booking.startTime,
-      endTime: booking.endTime,
+      startTime: this.toUtcIsoString(booking.startTime),
+      endTime: this.toUtcIsoString(booking.endTime),
     }));
 
     return { reservedTimes };
@@ -448,6 +448,24 @@ export class BookingService {
     endOfLocalDayUtcExclusive.setUTCDate(endOfLocalDayUtcExclusive.getUTCDate() + 1);
 
     return [localDayStartProxyUtc, endOfLocalDayUtcExclusive];
+  }
+
+  private toUtcIsoString(value: Date | string): string {
+    const dateValue = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(dateValue.getTime())) {
+      this.logger.warn(`Invalid booking timestamp found during serialization: ${value}`);
+      throw new BadRequestException('Invalid booking timestamp');
+    }
+
+    return dateValue.toISOString();
+  }
+
+  private serializeBookingTimestampFields<T extends { startTime: Date | string; endTime: Date | string }>(booking: T) {
+    return {
+      ...booking,
+      startTime: this.toUtcIsoString(booking.startTime),
+      endTime: this.toUtcIsoString(booking.endTime),
+    };
   }
 
   private validateTimeRange(startTime: Date, endTime: Date, action: string) {

--- a/src/migration/1762000000000-ConvertBookingTimesToTimestamptz.ts
+++ b/src/migration/1762000000000-ConvertBookingTimesToTimestamptz.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ConvertBookingTimesToTimestamptz1762000000000 implements MigrationInterface {
+  name = 'ConvertBookingTimesToTimestamptz1762000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS public.booking_timestamp_tz_backup_20260301 AS
+      SELECT
+        id,
+        "startTime",
+        "endTime",
+        NOW() AT TIME ZONE 'UTC' AS backed_up_at_utc
+      FROM public.booking;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE public.booking
+      ALTER COLUMN "startTime" TYPE timestamptz USING ("startTime" AT TIME ZONE 'America/Sao_Paulo'),
+      ALTER COLUMN "endTime" TYPE timestamptz USING ("endTime" AT TIME ZONE 'America/Sao_Paulo');
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE public.booking
+      ALTER COLUMN "startTime" TYPE timestamp WITHOUT TIME ZONE USING (timezone('America/Sao_Paulo', "startTime")),
+      ALTER COLUMN "endTime" TYPE timestamp WITHOUT TIME ZONE USING (timezone('America/Sao_Paulo', "endTime"));
+    `);
+  }
+}


### PR DESCRIPTION
This pull request introduces several important changes to ensure booking timestamps are consistently stored and serialized as UTC ISO strings throughout the application. The changes include a database migration to convert booking time columns to timezone-aware types, updates to the entity and service logic to handle UTC serialization, and improvements to related tests for robust timestamp handling.

**Database and Entity Updates:**

* Migrated the `booking.startTime` and `booking.endTime` columns in the database to use the `timestamptz` (timezone-aware) type, with a backup table created for safety. This ensures all timestamps are stored in UTC and are timezone-consistent. (`src/migration/1762000000000-ConvertBookingTimesToTimestamptz.ts`)
* Updated the `Booking` entity to explicitly use `timestamptz` for `startTime` and `endTime` columns. (`src/api/booking/entities/booking.entity.ts`)

**Service Logic and Serialization:**

* Modified the `BookingService` so that all returned `startTime` and `endTime` fields are serialized as UTC ISO strings, using new helper methods to enforce this format. This affects booking creation, updates, queries, and reserved times. (`src/api/booking/services/booking.service.ts`) [[1]](diffhunk://#diff-5ddb54fda252d081cee38871ee9965a6736715873316fcf3fd0fd9325ac1067bL85-R85) [[2]](diffhunk://#diff-5ddb54fda252d081cee38871ee9965a6736715873316fcf3fd0fd9325ac1067bL148-R148) [[3]](diffhunk://#diff-5ddb54fda252d081cee38871ee9965a6736715873316fcf3fd0fd9325ac1067bL260-R261) [[4]](diffhunk://#diff-5ddb54fda252d081cee38871ee9965a6736715873316fcf3fd0fd9325ac1067bL327-R328) [[5]](diffhunk://#diff-5ddb54fda252d081cee38871ee9965a6736715873316fcf3fd0fd9325ac1067bL403-R404) [[6]](diffhunk://#diff-5ddb54fda252d081cee38871ee9965a6736715873316fcf3fd0fd9325ac1067bR453-R470)

**Testing Improvements:**

* Updated and expanded tests to verify that booking timestamps are correctly serialized as UTC ISO strings, including edge cases for timezones and updates. (`src/api/booking/services/booking.service.spec.ts`) [[1]](diffhunk://#diff-ca707da227530559207f0b1a6444337c067f88915595371b569a396febc4f4abL77-R83) [[2]](diffhunk://#diff-ca707da227530559207f0b1a6444337c067f88915595371b569a396febc4f4abR115-R116) [[3]](diffhunk://#diff-ca707da227530559207f0b1a6444337c067f88915595371b569a396febc4f4abL117-R134) [[4]](diffhunk://#diff-ca707da227530559207f0b1a6444337c067f88915595371b569a396febc4f4abL150-R165) [[5]](diffhunk://#diff-ca707da227530559207f0b1a6444337c067f88915595371b569a396febc4f4abL191-R207) [[6]](diffhunk://#diff-ca707da227530559207f0b1a6444337c067f88915595371b569a396febc4f4abL208-R223) [[7]](diffhunk://#diff-ca707da227530559207f0b1a6444337c067f88915595371b569a396febc4f4abL232-R248) [[8]](diffhunk://#diff-ca707da227530559207f0b1a6444337c067f88915595371b569a396febc4f4abR260-R279) [[9]](diffhunk://#diff-ca707da227530559207f0b1a6444337c067f88915595371b569a396febc4f4abR532-R560) [[10]](diffhunk://#diff-ca707da227530559207f0b1a6444337c067f88915595371b569a396febc4f4abL530-R595) [[11]](diffhunk://#diff-6e066edb187d8ac95201339bd0af27e28335a913dfbedff09e84526fa8bf78e2L38-R41)

**Configuration Changes:**

* Set the default timezone to UTC in `.env.example` to reinforce UTC usage across environments. (`.env.example`)
* Disabled automatic database schema synchronization in `ormconfig.js` to prevent unintended schema changes in production. (`ormconfig.js`)…e ISO UTC serialization