### PR TITLE
Refactor user handling by removing legacy organization ID and register method

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,3 @@ DATABASE_PORT=5432
 DATABASE_USER=postgres
 DATABASE_PASSWORD=postgres
 DATABASE_NAME=grillrentapi
-
-# Multi-tenancy rollout seed (used by migration/data bootstrap docs)
-DEFAULT_ORGANIZATION_ID=9dd02335-74fa-487b-99f3-f3e6f9fba2af
-DEFAULT_ORGANIZATION_SLUG=legacy-default

--- a/src/api/user/controllers/user.controller.spec.ts
+++ b/src/api/user/controllers/user.controller.spec.ts
@@ -2,10 +2,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UserController } from './user.controller';
 import { UserService } from '../services/user.service';
 import { JwtAuthGuard } from '../../../shared/auth/guards/jwt-auth.guard';
-import { CreateUserDto, CreateUserSchema } from '../dto/create-user.dto';
 import { UpdateUserDto } from '../dto/update-user.dto';
 import { User, UserRole } from '../entities/user.entity';
-import { JoiValidationPipe } from '../../../shared/pipes/joi-validation.pipe';
 import { ForbiddenException, GoneException } from '@nestjs/common';
 
 describe('UserController', () => {
@@ -19,7 +17,6 @@ describe('UserController', () => {
         {
           provide: UserService,
           useValue: {
-            register: jest.fn(),
             getProfile: jest.fn(),
             updateProfile: jest.fn(),
             getAllUsers: jest.fn(),
@@ -41,21 +38,8 @@ describe('UserController', () => {
   });
 
   describe('register', () => {
-    it('should register a user', async () => {
-      const createUserDto: CreateUserDto = {
-        name: 'testuser',
-        password: 'password123', // 8 characters
-        email: 'testuser@example.com',
-        apartment: '101',
-        block: 1,
-        role: UserRole.RESIDENT,
-      };
-      const user: User = { id: '1', ...createUserDto };
-      const result = { message: 'User registered successfully', user };
-      jest.spyOn(service, 'register').mockResolvedValue(user);
-
-      const validationPipe = new JoiValidationPipe(CreateUserSchema);
-      expect(await controller.register(validationPipe.transform(createUserDto, { type: 'body' }))).toEqual(result);
+    it('should reject client-facing register because BFF owns auth ingress', async () => {
+      await expect(controller.register()).rejects.toThrow(GoneException);
     });
   });
 
@@ -131,7 +115,7 @@ describe('UserController', () => {
       const result = { message: 'All users retrieved successfully', users };
       jest.spyOn(service, 'getAllUsers').mockResolvedValue(result);
 
-      expect(await controller.getAllUsers()).toBe(result);
+      expect(await controller.getAllUsers({ organizationId: 'org-1' } as any)).toBe(result);
     });
   });
 

--- a/src/api/user/controllers/user.controller.ts
+++ b/src/api/user/controllers/user.controller.ts
@@ -1,8 +1,6 @@
 import { Controller, Post, Body, Logger, Get, Put, Delete, Param, Req, UseGuards, ForbiddenException, UnauthorizedException, GoneException } from '@nestjs/common';
-import { CreateUserDto, CreateUserSchema } from '../dto/create-user.dto';
 import { UpdateUserDto } from '../dto/update-user.dto';
 import { UserService } from '../services/user.service';
-import { JoiValidationPipe } from '../../../shared/pipes/joi-validation.pipe';
 import { JwtAuthGuard } from '../../../shared/auth/guards/jwt-auth.guard';
 import { User } from '../../../shared/auth/decorators/user.decorator';
 import { User as UserEntity, UserRole } from '../entities/user.entity';
@@ -14,10 +12,8 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Post('register')
-  async register(@Body(new JoiValidationPipe(CreateUserSchema)) createUserDto: CreateUserDto) {
-    this.logger.log(`Registering user: ${createUserDto.name}`);
-    const user = await this.userService.register(createUserDto);
-    return { message: 'User registered successfully', user };
+  async register() {
+    throw new GoneException('This endpoint is deprecated. Use POST /users/register in grillrentbff_v2.');
   }
 
   @Post('login')

--- a/src/api/user/services/user.service.spec.ts
+++ b/src/api/user/services/user.service.spec.ts
@@ -3,22 +3,12 @@ import { UserService } from './user.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { User, UserRole } from '../entities/user.entity';
 import { Repository } from 'typeorm';
-import * as bcrypt from 'bcrypt';
-import { ConflictException, UnauthorizedException, NotFoundException, ForbiddenException } from '@nestjs/common';
-import { CreateUserDto } from '../dto/create-user.dto';
+import { UnauthorizedException, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { UpdateUserDto } from '../dto/update-user.dto';
-import { ConfigService } from '@nestjs/config';
 
 describe('UserService', () => {
   let service: UserService;
   let repository: Repository<User>;
-  const configService = {
-    get: jest.fn((key: string) => {
-      if (key === 'DEFAULT_ORGANIZATION_ID') return '9dd02335-74fa-487b-99f3-f3e6f9fba2af';
-      if (key === 'NODE_ENV') return 'test';
-      return undefined;
-    }),
-  };
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -29,10 +19,6 @@ describe('UserService', () => {
           provide: getRepositoryToken(User),
           useClass: Repository,
         },
-        {
-          provide: ConfigService,
-          useValue: configService,
-        },
       ],
     }).compile();
 
@@ -42,81 +28,6 @@ describe('UserService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
-  });
-
-  it('throws when DEFAULT_ORGANIZATION_ID is missing in production-like env', () => {
-    const missingInProductionConfig = {
-      get: jest.fn((key: string) => {
-        if (key === 'DEFAULT_ORGANIZATION_ID') return undefined;
-        if (key === 'NODE_ENV') return 'production';
-        return undefined;
-      }),
-    };
-
-    expect(() => new UserService({} as Repository<User>, missingInProductionConfig as any)).toThrow(
-      'DEFAULT_ORGANIZATION_ID must be configured in non-local environments',
-    );
-  });
-
-  it('falls back to seeded org id when DEFAULT_ORGANIZATION_ID is missing in local-like env', () => {
-    const missingInTestConfig = {
-      get: jest.fn((key: string) => {
-        if (key === 'DEFAULT_ORGANIZATION_ID') return undefined;
-        if (key === 'NODE_ENV') return 'test';
-        return undefined;
-      }),
-    };
-
-    const localService = new UserService({} as Repository<User>, missingInTestConfig as any);
-    expect((localService as any).defaultOrganizationId).toBe('9dd02335-74fa-487b-99f3-f3e6f9fba2af');
-  });
-
-  it('throws when DEFAULT_ORGANIZATION_ID is not a valid UUID', () => {
-    const invalidDefaultConfig = {
-      get: jest.fn((key: string) => {
-        if (key === 'DEFAULT_ORGANIZATION_ID') return 'invalid';
-        if (key === 'NODE_ENV') return 'production';
-        return undefined;
-      }),
-    };
-
-    expect(() => new UserService({} as Repository<User>, invalidDefaultConfig as any)).toThrow(
-      'DEFAULT_ORGANIZATION_ID must be a valid UUID',
-    );
-  });
-
-  describe('register', () => {
-    it('should register a user', async () => {
-      const createUserDto: CreateUserDto = {
-        name: 'testuser',
-        password: 'password123',
-        email: 'testuser@example.com',
-        apartment: '101',
-        block: 1,
-        role: UserRole.RESIDENT,
-      };
-      const user: User = { id: '1', organizationId: '9dd02335-74fa-487b-99f3-f3e6f9fba2af', ...createUserDto };
-      jest.spyOn(repository, 'findOne').mockResolvedValue(null);
-      jest.spyOn(bcrypt, 'hash').mockResolvedValue('hashedpassword' as never);
-      jest.spyOn(repository, 'create').mockReturnValue(user as any);
-      jest.spyOn(repository, 'save').mockResolvedValue(user as any);
-
-      expect(await service.register(createUserDto)).toEqual(user);
-    });
-
-    it('should throw a ConflictException if name, email, or apartment already exists', async () => {
-      const createUserDto: CreateUserDto = {
-        name: 'testuser',
-        password: 'password123',
-        email: 'testuser@example.com',
-        apartment: '101',
-        block: 1,
-        role: UserRole.RESIDENT,
-      };
-      jest.spyOn(repository, 'findOne').mockResolvedValue(createUserDto as any);
-
-      await expect(service.register(createUserDto)).rejects.toThrow(ConflictException);
-    });
   });
 
   describe('getProfile', () => {

--- a/src/api/user/services/user.service.ts
+++ b/src/api/user/services/user.service.ts
@@ -1,43 +1,18 @@
-import { Injectable, UnauthorizedException, Logger, ConflictException, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { Injectable, UnauthorizedException, Logger, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { CreateUserDto } from '../dto/create-user.dto';
 import { UpdateUserDto } from '../dto/update-user.dto';
 import { User, UserRole } from '../entities/user.entity';
 import * as bcrypt from 'bcrypt';
-import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class UserService {
   private readonly logger = new Logger(UserService.name);
-  private readonly defaultOrganizationId: string;
-  private static readonly LEGACY_DEFAULT_ORGANIZATION_ID = '9dd02335-74fa-487b-99f3-f3e6f9fba2af';
-  private static readonly LOCAL_LIKE_ENVS = new Set(['local', 'development', 'dev', 'test']);
 
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
-    private readonly configService: ConfigService,
-  ) {
-    this.defaultOrganizationId = this.resolveDefaultOrganizationId();
-  }
-
-  async register(createUserDto: CreateUserDto) {
-    const { name, email, apartment, block, password, role } = createUserDto;
-    const organizationId = this.defaultOrganizationId;
-
-    const existingUser = await this.userRepository.findOne({
-      where: [{ email, organizationId }, { apartment, block, organizationId }],
-    });
-
-    if (existingUser) {
-      throw new ConflictException('Email, apartment or block already in use for this organization');
-    }
-
-    const hashedPassword = await bcrypt.hash(password, 10);
-    const user = this.userRepository.create({ name, email, apartment, block, role, password: hashedPassword, organizationId });
-    return this.userRepository.save(user);
-  }
+  ) {}
 
   async getProfile(userId: string, organizationId: string) {
     this.logger.log(`Fetching profile for user ID: ${userId}`);
@@ -96,28 +71,5 @@ export class UserService {
     await this.userRepository.remove(user);
     this.logger.log(`User removed successfully: ${userId}`);
     return { message: 'User removed successfully' };
-  }
-
-  private resolveDefaultOrganizationId(): string {
-    const configuredDefaultOrganizationId = this.configService.get<string>('DEFAULT_ORGANIZATION_ID');
-    const nodeEnv = (this.configService.get<string>('NODE_ENV') || '').trim().toLowerCase();
-    const isLocalLikeEnv = UserService.LOCAL_LIKE_ENVS.has(nodeEnv);
-
-    if (!configuredDefaultOrganizationId) {
-      if (isLocalLikeEnv) {
-        return UserService.LEGACY_DEFAULT_ORGANIZATION_ID;
-      }
-      throw new Error('DEFAULT_ORGANIZATION_ID must be configured in non-local environments');
-    }
-
-    const normalizedOrganizationId = configuredDefaultOrganizationId.trim().toLowerCase();
-    const isValidUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-      normalizedOrganizationId,
-    );
-    if (!isValidUuid) {
-      throw new Error('DEFAULT_ORGANIZATION_ID must be a valid UUID');
-    }
-
-    return normalizedOrganizationId;
   }
 }


### PR DESCRIPTION
This pull request removes support for user registration from the `UserController` and related service and test files, as user registration is now handled by the BFF (Backend For Frontend) service. It also removes all logic and configuration related to the default organization ID, simplifying the codebase and test setup. The `.env.example` file is updated to remove organization-related seed variables.

**User registration deprecation and removal:**

* The `register` endpoint in `UserController` (`user.controller.ts`) now throws a `GoneException`, indicating it's deprecated and directing clients to use the BFF endpoint instead. All registration logic and DTO validation are removed from the controller.
* All tests for user registration in `user.controller.spec.ts` and `user.service.spec.ts` are removed or updated to reflect the deprecation. The controller test now expects a `GoneException` for registration attempts. [[1]](diffhunk://#diff-a0b11f910c987fcf3018536c74f7b2d7209ec9eb72c7609716cdaaaeab6349baL44-R42) [[2]](diffhunk://#diff-19b1b7b70ba056e252fa89d1f289d75d23fadbdc5fe6f9632b60144fb4437902L47-L121)

**Default organization ID and configuration cleanup:**

* All code, configuration, and tests related to `DEFAULT_ORGANIZATION_ID` are removed from `UserService` and its tests, including environment-based logic and validation for the organization ID. [[1]](diffhunk://#diff-80b0379135987ebe65eedb18df3a35c99d9ac724efe8333150e8cacf9eae6f54L1-R15) [[2]](diffhunk://#diff-80b0379135987ebe65eedb18df3a35c99d9ac724efe8333150e8cacf9eae6f54L100-L122) [[3]](diffhunk://#diff-19b1b7b70ba056e252fa89d1f289d75d23fadbdc5fe6f9632b60144fb4437902L6-L21) [[4]](diffhunk://#diff-19b1b7b70ba056e252fa89d1f289d75d23fadbdc5fe6f9632b60144fb4437902L32-L35) [[5]](diffhunk://#diff-19b1b7b70ba056e252fa89d1f289d75d23fadbdc5fe6f9632b60144fb4437902L47-L121)
* The `.env.example` file is updated to remove organization seed variables, reflecting that these are no longer needed.

**Test and DTO import cleanup:**

* Unused imports related to registration DTOs and validation pipes are removed from controller and service test files. [[1]](diffhunk://#diff-a0b11f910c987fcf3018536c74f7b2d7209ec9eb72c7609716cdaaaeab6349baL5-L8) [[2]](diffhunk://#diff-e460ba36a95ad6eb563696f3a297d61f7fbb70acfb759aa53dc5ed5f629029eeL2-L5) [[3]](diffhunk://#diff-19b1b7b70ba056e252fa89d1f289d75d23fadbdc5fe6f9632b60144fb4437902L6-L21)

**Minor test adjustments:**

* The `getAllUsers` test in `user.controller.spec.ts` is updated to accept an organization ID as input, matching the current method signature.… register method