### PR TITLE
Implement unread count and mark as seen functionality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,12 @@ DATABASE_PORT=5432
 DATABASE_USER=postgres
 DATABASE_PASSWORD=postgres
 DATABASE_NAME=grillrentapi
+
+# WhatsApp Evolution integration (consumed by grillrentapi)
+WHATSAPP_EVOLUTION_BASE_URL=https://your-evolution-url.example.com
+WHATSAPP_EVOLUTION_INSTANCE=your-instance-name
+WHATSAPP_EVOLUTION_API_KEY=replace-with-your-evolution-api-key
+WHATSAPP_GROUP_JID_BY_ORG={"your-organization-uuid":"120363xxxxxxxxxxxx@g.us"}
+WHATSAPP_SEND_MAX_ATTEMPTS=3
+WHATSAPP_SEND_BASE_BACKOFF_MS=250
+WHATSAPP_SEND_TIMEOUT_MS=8000

--- a/deploy/evolution/railway/Dockerfile
+++ b/deploy/evolution/railway/Dockerfile
@@ -1,0 +1,10 @@
+FROM atendai/evolution-api:v2.2.3
+
+WORKDIR /evolution
+
+COPY deploy/evolution/railway/start-evolution.sh /usr/local/bin/start-evolution.sh
+RUN chmod +x /usr/local/bin/start-evolution.sh
+
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/start-evolution.sh"]

--- a/deploy/evolution/railway/start-evolution.sh
+++ b/deploy/evolution/railway/start-evolution.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+set -eu
+
+# Railway injects PORT dynamically. Keep explicit fallback for local smoke tests.
+export SERVER_TYPE="${SERVER_TYPE:-http}"
+export SERVER_HOST="${SERVER_HOST:-0.0.0.0}"
+export SERVER_PORT="${PORT:-${SERVER_PORT:-8080}}"
+export PORT="${SERVER_PORT}"
+
+echo "[railway-evolution] starting with SERVER_HOST=${SERVER_HOST} SERVER_PORT=${SERVER_PORT}"
+
+# Evolution image already has dependencies and scripts.
+exec npm run start

--- a/src/api/notice/controllers/notice.controller.spec.ts
+++ b/src/api/notice/controllers/notice.controller.spec.ts
@@ -1,0 +1,68 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NoticeController } from './notice.controller';
+import { NoticeService } from '../services/notice.service';
+import { JwtAuthGuard } from '../../../shared/auth/guards/jwt-auth.guard';
+import { UserRole } from '../../user/entities/user.entity';
+import { ForbiddenException } from '@nestjs/common';
+
+describe('NoticeController', () => {
+  let controller: NoticeController;
+  let service: jest.Mocked<NoticeService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [NoticeController],
+      providers: [
+        {
+          provide: NoticeService,
+          useValue: {
+            create: jest.fn(),
+            findAll: jest.fn(),
+            update: jest.fn(),
+            delete: jest.fn(),
+            getUnreadCount: jest.fn(),
+            markAllAsSeen: jest.fn(),
+          },
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<NoticeController>(NoticeController);
+    service = module.get(NoticeService) as jest.Mocked<NoticeService>;
+  });
+
+  it('returns unread count for authenticated user', async () => {
+    service.getUnreadCount.mockResolvedValue({ unreadCount: 3, lastSeenNoticesAt: null });
+
+    await expect(
+      controller.getUnreadCount({ user: { id: 'user-1', organizationId: 'org-1' } } as any),
+    ).resolves.toEqual({ unreadCount: 3, lastSeenNoticesAt: null });
+    expect(service.getUnreadCount).toHaveBeenCalledWith('user-1', 'org-1');
+  });
+
+  it('marks notices as seen for authenticated user', async () => {
+    service.markAllAsSeen.mockResolvedValue({
+      markedAsSeenAt: '2026-03-09T11:00:00.000Z',
+      previousLastSeenNoticesAt: null,
+    });
+
+    await expect(
+      controller.markAsSeen({ user: { id: 'user-1', organizationId: 'org-1' } } as any),
+    ).resolves.toEqual({
+      markedAsSeenAt: '2026-03-09T11:00:00.000Z',
+      previousLastSeenNoticesAt: null,
+    });
+    expect(service.markAllAsSeen).toHaveBeenCalledWith('user-1', 'org-1');
+  });
+
+  it('blocks non-admin create operation', async () => {
+    await expect(
+      controller.create({ title: 'x' } as any, {
+        user: { role: UserRole.RESIDENT, organizationId: 'org-1' },
+      } as any),
+    ).rejects.toThrow(ForbiddenException);
+  });
+});

--- a/src/api/notice/controllers/notice.controller.ts
+++ b/src/api/notice/controllers/notice.controller.ts
@@ -4,6 +4,9 @@ import { Notice } from '../entities/notice.entity';
 import { JwtAuthGuard } from '../../../shared/auth/guards/jwt-auth.guard';
 import { UserRole } from '../../user/entities/user.entity';
 import { Request } from 'express';
+import { JoiValidationPipe } from '../../../shared/pipes/joi-validation.pipe';
+import { CreateNoticeDto, CreateNoticeSchema } from '../dto/create-notice.dto';
+import { UpdateNoticeDto, UpdateNoticeSchema } from '../dto/update-notice.dto';
 
 interface AuthenticatedRequest extends Request {
   user: { id: string; role: string; organizationId: string };
@@ -15,7 +18,10 @@ export class NoticeController {
 
   @UseGuards(JwtAuthGuard)
   @Post()
-  async create(@Body() data: Partial<Notice>, @Req() req: AuthenticatedRequest): Promise<Notice> {
+  async create(
+    @Body(new JoiValidationPipe(CreateNoticeSchema)) data: CreateNoticeDto,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<Notice> {
     if (req.user.role !== UserRole.ADMIN) {
       throw new ForbiddenException('You do not have permission to create notices');
     }
@@ -49,7 +55,11 @@ export class NoticeController {
 
   @UseGuards(JwtAuthGuard)
   @Put(':id')
-  async update(@Param('id') id: string, @Body() data: Partial<Notice>, @Req() req: AuthenticatedRequest): Promise<Notice> {
+  async update(
+    @Param('id') id: string,
+    @Body(new JoiValidationPipe(UpdateNoticeSchema)) data: UpdateNoticeDto,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<Notice> {
     if (req.user.role !== UserRole.ADMIN) {
       throw new ForbiddenException('You do not have permission to update notices');
     }

--- a/src/api/notice/controllers/notice.controller.ts
+++ b/src/api/notice/controllers/notice.controller.ts
@@ -34,6 +34,20 @@ export class NoticeController {
   }
 
   @UseGuards(JwtAuthGuard)
+  @Get('unread-count')
+  async getUnreadCount(@Req() req: AuthenticatedRequest): Promise<{ unreadCount: number; lastSeenNoticesAt: string | null }> {
+    return this.noticeService.getUnreadCount(req.user.id, req.user.organizationId);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('mark-seen')
+  async markAsSeen(
+    @Req() req: AuthenticatedRequest,
+  ): Promise<{ markedAsSeenAt: string; previousLastSeenNoticesAt: string | null }> {
+    return this.noticeService.markAllAsSeen(req.user.id, req.user.organizationId);
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Put(':id')
   async update(@Param('id') id: string, @Body() data: Partial<Notice>, @Req() req: AuthenticatedRequest): Promise<Notice> {
     if (req.user.role !== UserRole.ADMIN) {

--- a/src/api/notice/dto/create-notice.dto.ts
+++ b/src/api/notice/dto/create-notice.dto.ts
@@ -1,0 +1,15 @@
+import * as Joi from '@hapi/joi';
+
+export const CreateNoticeSchema = Joi.object({
+  title: Joi.string().trim().max(255).required(),
+  subtitle: Joi.string().trim().max(255).allow('', null).optional(),
+  content: Joi.string().trim().max(2000).required(),
+  sendViaWhatsapp: Joi.boolean().optional(),
+});
+
+export class CreateNoticeDto {
+  title!: string;
+  subtitle?: string;
+  content!: string;
+  sendViaWhatsapp?: boolean;
+}

--- a/src/api/notice/dto/update-notice.dto.ts
+++ b/src/api/notice/dto/update-notice.dto.ts
@@ -1,0 +1,13 @@
+import * as Joi from '@hapi/joi';
+
+export const UpdateNoticeSchema = Joi.object({
+  title: Joi.string().trim().max(255).optional(),
+  subtitle: Joi.string().trim().max(255).allow('', null).optional(),
+  content: Joi.string().trim().max(2000).optional(),
+}).min(1);
+
+export class UpdateNoticeDto {
+  title?: string;
+  subtitle?: string;
+  content?: string;
+}

--- a/src/api/notice/entities/notice-read-state.entity.ts
+++ b/src/api/notice/entities/notice-read-state.entity.ts
@@ -1,0 +1,24 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, Unique, UpdateDateColumn } from 'typeorm';
+
+@Entity('notice_read_state')
+@Unique('UQ_notice_read_state_user_org', ['userId', 'organizationId'])
+@Index('IDX_notice_read_state_org_user', ['organizationId', 'userId'])
+export class NoticeReadState {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @Column({ type: 'uuid' })
+  organizationId: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  lastSeenNoticesAt: Date | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/api/notice/entities/notice.entity.ts
+++ b/src/api/notice/entities/notice.entity.ts
@@ -1,5 +1,13 @@
 import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
 
+export type NoticeWhatsappDeliveryStatus =
+  | 'not_requested'
+  | 'pending'
+  | 'retrying'
+  | 'sent'
+  | 'failed'
+  | 'skipped';
+
 @Entity('notice')
 export class Notice {
   @PrimaryGeneratedColumn('uuid')
@@ -13,6 +21,27 @@ export class Notice {
 
   @Column('text')
   content: string;
+
+  @Column({ type: 'boolean', default: false })
+  sendViaWhatsapp: boolean;
+
+  @Column({ type: 'varchar', length: 32, default: 'not_requested' })
+  whatsappDeliveryStatus: NoticeWhatsappDeliveryStatus;
+
+  @Column({ type: 'int', default: 0 })
+  whatsappAttemptCount: number;
+
+  @Column({ type: 'timestamp', nullable: true })
+  whatsappLastAttemptAt?: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  whatsappSentAt?: Date;
+
+  @Column({ type: 'varchar', length: 128, nullable: true })
+  whatsappProviderMessageId?: string;
+
+  @Column({ type: 'text', nullable: true })
+  whatsappLastError?: string;
 
   @Column({ type: 'uuid', nullable: true })
   organizationId?: string;

--- a/src/api/notice/entities/notice.entity.ts
+++ b/src/api/notice/entities/notice.entity.ts
@@ -32,16 +32,16 @@ export class Notice {
   whatsappAttemptCount: number;
 
   @Column({ type: 'timestamp', nullable: true })
-  whatsappLastAttemptAt?: Date;
+  whatsappLastAttemptAt?: Date | null;
 
   @Column({ type: 'timestamp', nullable: true })
-  whatsappSentAt?: Date;
+  whatsappSentAt?: Date | null;
 
   @Column({ type: 'varchar', length: 128, nullable: true })
-  whatsappProviderMessageId?: string;
+  whatsappProviderMessageId?: string | null;
 
   @Column({ type: 'text', nullable: true })
-  whatsappLastError?: string;
+  whatsappLastError?: string | null;
 
   @Column({ type: 'uuid', nullable: true })
   organizationId?: string;

--- a/src/api/notice/notice.module.ts
+++ b/src/api/notice/notice.module.ts
@@ -3,10 +3,11 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { NoticeService } from './services/notice.service';
 import { NoticeController } from './controllers/notice.controller';
 import { Notice } from './entities/notice.entity';
+import { NoticeReadState } from './entities/notice-read-state.entity';
 import { UserModule } from '../user/user.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Notice]), UserModule],
+  imports: [TypeOrmModule.forFeature([Notice, NoticeReadState]), UserModule],
   controllers: [NoticeController],
   providers: [NoticeService],
   exports: [NoticeService],

--- a/src/api/notice/services/notice.service.spec.ts
+++ b/src/api/notice/services/notice.service.spec.ts
@@ -1,0 +1,99 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NoticeService } from './notice.service';
+import { Notice } from '../entities/notice.entity';
+import { NoticeReadState } from '../entities/notice-read-state.entity';
+
+describe('NoticeService', () => {
+  let service: NoticeService;
+  let noticeRepository: jest.Mocked<Repository<Notice>>;
+  let noticeReadStateRepository: jest.Mocked<Repository<NoticeReadState>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NoticeService,
+        { provide: getRepositoryToken(Notice), useClass: Repository },
+        { provide: getRepositoryToken(NoticeReadState), useClass: Repository },
+      ],
+    }).compile();
+
+    service = module.get<NoticeService>(NoticeService);
+    noticeRepository = module.get(getRepositoryToken(Notice));
+    noticeReadStateRepository = module.get(getRepositoryToken(NoticeReadState));
+  });
+
+  it('returns all organization notices as unread when read state does not exist', async () => {
+    jest.spyOn(noticeReadStateRepository, 'findOne').mockResolvedValue(null);
+    jest.spyOn(noticeRepository, 'count').mockResolvedValue(4);
+
+    await expect(service.getUnreadCount('user-1', 'org-1')).resolves.toEqual({
+      unreadCount: 4,
+      lastSeenNoticesAt: null,
+    });
+
+    expect(noticeRepository.count).toHaveBeenCalledWith({
+      where: { organizationId: 'org-1' },
+    });
+  });
+
+  it('counts unread notices newer than lastSeenNoticesAt', async () => {
+    const lastSeenNoticesAt = new Date('2026-03-01T10:00:00.000Z');
+
+    jest.spyOn(noticeReadStateRepository, 'findOne').mockResolvedValue({
+      id: 'state-1',
+      userId: 'user-1',
+      organizationId: 'org-1',
+      lastSeenNoticesAt,
+      createdAt: new Date('2026-03-01T10:00:00.000Z'),
+      updatedAt: new Date('2026-03-01T10:00:00.000Z'),
+    } as NoticeReadState);
+    jest.spyOn(noticeRepository, 'count').mockResolvedValue(2);
+
+    const result = await service.getUnreadCount('user-1', 'org-1');
+
+    expect(result.unreadCount).toBe(2);
+    expect(result.lastSeenNoticesAt).toBe(lastSeenNoticesAt.toISOString());
+    expect(noticeRepository.count).toHaveBeenCalledWith({
+      where: expect.objectContaining({ organizationId: 'org-1' }),
+    });
+  });
+
+  it('creates read state when marking seen for first time', async () => {
+    jest.spyOn(noticeReadStateRepository, 'findOne').mockResolvedValue(null);
+    jest.spyOn(noticeReadStateRepository, 'query').mockResolvedValue([
+      { lastSeenNoticesAt: '2026-03-09T10:00:00.123Z' },
+    ]);
+
+    const result = await service.markAllAsSeen('user-1', 'org-1');
+
+    expect(noticeReadStateRepository.query).toHaveBeenCalled();
+    expect(result.previousLastSeenNoticesAt).toBeNull();
+    expect(result.markedAsSeenAt).toBe('2026-03-09T10:00:00.123Z');
+  });
+
+  it('updates read state inside organization scope', async () => {
+    const existing = {
+      id: 'state-1',
+      userId: 'user-1',
+      organizationId: 'org-1',
+      lastSeenNoticesAt: new Date('2026-03-02T10:00:00.000Z'),
+      createdAt: new Date('2026-03-02T10:00:00.000Z'),
+      updatedAt: new Date('2026-03-02T10:00:00.000Z'),
+    } as NoticeReadState;
+
+    jest.spyOn(noticeReadStateRepository, 'findOne').mockResolvedValue(existing);
+    jest.spyOn(noticeReadStateRepository, 'query').mockResolvedValue([
+      { lastSeenNoticesAt: '2026-03-09T11:00:00.789Z' },
+    ]);
+
+    const result = await service.markAllAsSeen('user-1', 'org-1');
+
+    expect(noticeReadStateRepository.findOne).toHaveBeenCalledWith({
+      where: { userId: 'user-1', organizationId: 'org-1' },
+    });
+    expect(result.previousLastSeenNoticesAt).toBe('2026-03-02T10:00:00.000Z');
+    expect(result.markedAsSeenAt).toBe('2026-03-09T11:00:00.789Z');
+  });
+});

--- a/src/api/notice/services/notice.service.spec.ts
+++ b/src/api/notice/services/notice.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { NoticeService } from './notice.service';
@@ -9,6 +10,17 @@ describe('NoticeService', () => {
   let service: NoticeService;
   let noticeRepository: jest.Mocked<Repository<Notice>>;
   let noticeReadStateRepository: jest.Mocked<Repository<NoticeReadState>>;
+  let configService: jest.Mocked<ConfigService>;
+
+  const defaultEnv: Record<string, string> = {
+    WHATSAPP_EVOLUTION_BASE_URL: 'https://evolution.example.com',
+    WHATSAPP_EVOLUTION_INSTANCE: 'instance-a',
+    WHATSAPP_EVOLUTION_API_KEY: 'secret',
+    WHATSAPP_GROUP_JID_BY_ORG: JSON.stringify({ 'org-1': '120363000000000000@g.us' }),
+    WHATSAPP_SEND_MAX_ATTEMPTS: '2',
+    WHATSAPP_SEND_BASE_BACKOFF_MS: '1',
+    WHATSAPP_SEND_TIMEOUT_MS: '1000',
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -16,12 +28,23 @@ describe('NoticeService', () => {
         NoticeService,
         { provide: getRepositoryToken(Notice), useClass: Repository },
         { provide: getRepositoryToken(NoticeReadState), useClass: Repository },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => defaultEnv[key]),
+          },
+        },
       ],
     }).compile();
 
     service = module.get<NoticeService>(NoticeService);
     noticeRepository = module.get(getRepositoryToken(Notice));
     noticeReadStateRepository = module.get(getRepositoryToken(NoticeReadState));
+    configService = module.get(ConfigService);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('returns all organization notices as unread when read state does not exist', async () => {
@@ -95,5 +118,159 @@ describe('NoticeService', () => {
     });
     expect(result.previousLastSeenNoticesAt).toBe('2026-03-02T10:00:00.000Z');
     expect(result.markedAsSeenAt).toBe('2026-03-09T11:00:00.789Z');
+  });
+
+  it('sends whatsapp once and marks notice as sent', async () => {
+    const createdNotice = {
+      id: 'notice-1',
+      title: 'Titulo',
+      subtitle: 'Subtitulo',
+      content: 'Mensagem',
+      sendViaWhatsapp: true,
+      organizationId: 'org-1',
+      whatsappDeliveryStatus: 'pending',
+      whatsappAttemptCount: 0,
+    } as Notice;
+
+    jest.spyOn(noticeRepository, 'create').mockReturnValue(createdNotice);
+
+    const saveSpy = jest
+      .spyOn(noticeRepository, 'save')
+      .mockResolvedValueOnce(createdNotice)
+      .mockImplementation(async (value: Notice) => value as Notice);
+
+    jest.spyOn(noticeRepository, 'findOne').mockResolvedValue(createdNotice);
+
+    (global.fetch as jest.Mock | undefined) = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ key: { id: 'provider-123' } }),
+    });
+
+    const result = await service.create(
+      {
+        title: 'Titulo',
+        subtitle: 'Subtitulo',
+        content: 'Mensagem',
+        sendViaWhatsapp: true,
+      },
+      'org-1',
+    );
+
+    expect(saveSpy).toHaveBeenCalled();
+    expect(result.whatsappDeliveryStatus).toBe('sent');
+    expect(result.whatsappProviderMessageId).toBe('provider-123');
+    expect(result.whatsappAttemptCount).toBe(1);
+  });
+
+  it('does not send duplicate provider message when already sent', async () => {
+    const alreadySent = {
+      id: 'notice-2',
+      title: 'Titulo',
+      content: 'Mensagem',
+      sendViaWhatsapp: true,
+      organizationId: 'org-1',
+      whatsappDeliveryStatus: 'sent',
+      whatsappProviderMessageId: 'provider-abc',
+      whatsappAttemptCount: 1,
+    } as Notice;
+
+    jest.spyOn(noticeRepository, 'create').mockReturnValue(alreadySent);
+    jest.spyOn(noticeRepository, 'save').mockResolvedValue(alreadySent);
+    jest.spyOn(noticeRepository, 'findOne').mockResolvedValue(alreadySent);
+
+    (global.fetch as jest.Mock | undefined) = jest.fn();
+
+    const result = await service.create(
+      {
+        title: 'Titulo',
+        content: 'Mensagem',
+        sendViaWhatsapp: true,
+      },
+      'org-1',
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.whatsappDeliveryStatus).toBe('sent');
+  });
+
+  it('marks notice as failed when provider fails after retries', async () => {
+    const createdNotice = {
+      id: 'notice-3',
+      title: 'Titulo',
+      content: 'Mensagem',
+      sendViaWhatsapp: true,
+      organizationId: 'org-1',
+      whatsappDeliveryStatus: 'pending',
+      whatsappAttemptCount: 0,
+    } as Notice;
+
+    jest.spyOn(noticeRepository, 'create').mockReturnValue(createdNotice);
+    jest
+      .spyOn(noticeRepository, 'save')
+      .mockResolvedValueOnce(createdNotice)
+      .mockImplementation(async (value: Notice) => value as Notice);
+    jest.spyOn(noticeRepository, 'findOne').mockResolvedValue(createdNotice);
+
+    (global.fetch as jest.Mock | undefined) = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => JSON.stringify({ message: 'temporary error' }),
+    });
+
+    const result = await service.create(
+      {
+        title: 'Titulo',
+        content: 'Mensagem',
+        sendViaWhatsapp: true,
+      },
+      'org-1',
+    );
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(result.whatsappDeliveryStatus).toBe('failed');
+    expect(result.whatsappAttemptCount).toBe(2);
+    expect(result.whatsappLastError).toContain('Provider rejected notice message');
+  });
+
+  it('marks as skipped when organization whatsapp group is not configured', async () => {
+    jest.spyOn(configService, 'get').mockImplementation((key: string) => {
+      if (key === 'WHATSAPP_GROUP_JID_BY_ORG') {
+        return JSON.stringify({});
+      }
+      return defaultEnv[key];
+    });
+
+    const createdNotice = {
+      id: 'notice-4',
+      title: 'Titulo',
+      content: 'Mensagem',
+      sendViaWhatsapp: true,
+      organizationId: 'org-1',
+      whatsappDeliveryStatus: 'pending',
+      whatsappAttemptCount: 0,
+    } as Notice;
+
+    jest.spyOn(noticeRepository, 'create').mockReturnValue(createdNotice);
+    jest
+      .spyOn(noticeRepository, 'save')
+      .mockResolvedValueOnce(createdNotice)
+      .mockImplementation(async (value: Notice) => value as Notice);
+    jest.spyOn(noticeRepository, 'findOne').mockResolvedValue(createdNotice);
+
+    (global.fetch as jest.Mock | undefined) = jest.fn();
+
+    const result = await service.create(
+      {
+        title: 'Titulo',
+        content: 'Mensagem',
+        sendViaWhatsapp: true,
+      },
+      'org-1',
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.whatsappDeliveryStatus).toBe('skipped');
+    expect(result.whatsappLastError).toContain('not configured');
   });
 });

--- a/src/api/notice/services/notice.service.ts
+++ b/src/api/notice/services/notice.service.ts
@@ -1,13 +1,18 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { MoreThan, Repository } from 'typeorm';
 import { Notice } from '../entities/notice.entity';
+import { NoticeReadState } from '../entities/notice-read-state.entity';
 
 @Injectable()
 export class NoticeService {
+  private readonly logger = new Logger(NoticeService.name);
+
   constructor(
     @InjectRepository(Notice)
     private readonly noticeRepository: Repository<Notice>,
+    @InjectRepository(NoticeReadState)
+    private readonly noticeReadStateRepository: Repository<NoticeReadState>,
   ) {}
 
   async create(data: Partial<Notice>, organizationId: string): Promise<Notice> {
@@ -43,5 +48,84 @@ export class NoticeService {
     if (result.affected === 0) {
       throw new NotFoundException('Notice not found');
     }
+  }
+
+  async getUnreadCount(
+    userId: string,
+    organizationId: string,
+  ): Promise<{ unreadCount: number; lastSeenNoticesAt: string | null }> {
+    const readState = await this.noticeReadStateRepository.findOne({
+      where: { userId, organizationId },
+    });
+
+    const lastSeenNoticesAt = readState?.lastSeenNoticesAt ?? null;
+    const unreadCount = await this.noticeRepository.count({
+      where: {
+        organizationId,
+        ...(lastSeenNoticesAt ? { createdAt: MoreThan(lastSeenNoticesAt) } : {}),
+      },
+    });
+
+    this.logger.log(
+      JSON.stringify({
+        event: 'notice_unread_count_fetched',
+        organizationId,
+        unreadCount,
+        hasReadState: Boolean(readState),
+      }),
+    );
+
+    return {
+      unreadCount,
+      lastSeenNoticesAt: lastSeenNoticesAt ? lastSeenNoticesAt.toISOString() : null,
+    };
+  }
+
+  async markAllAsSeen(
+    userId: string,
+    organizationId: string,
+  ): Promise<{ markedAsSeenAt: string; previousLastSeenNoticesAt: string | null }> {
+    const readState = await this.noticeReadStateRepository.findOne({
+      where: { userId, organizationId },
+    });
+    const previousLastSeenNoticesAt = readState?.lastSeenNoticesAt
+      ? readState.lastSeenNoticesAt.toISOString()
+      : null;
+    const [result] = (await this.noticeReadStateRepository.query(
+      `
+        INSERT INTO "notice_read_state" ("userId", "organizationId", "lastSeenNoticesAt")
+        VALUES (
+          $1,
+          $2,
+          (
+            SELECT COALESCE(MAX("createdAt") + interval '1 microsecond', now())
+            FROM "notice"
+            WHERE "organizationId" = $2
+          )
+        )
+        ON CONFLICT ("userId", "organizationId")
+        DO UPDATE SET
+          "lastSeenNoticesAt" = EXCLUDED."lastSeenNoticesAt",
+          "updatedAt" = now()
+        RETURNING "lastSeenNoticesAt"
+      `,
+      [userId, organizationId],
+    )) as Array<{ lastSeenNoticesAt: string | Date }>;
+    const seenAtValue = result?.lastSeenNoticesAt ?? new Date();
+    const seenAt = new Date(seenAtValue);
+
+    this.logger.log(
+      JSON.stringify({
+        event: 'notice_mark_seen_succeeded',
+        organizationId,
+        hadPreviousReadState: Boolean(readState),
+        markedToLatestNoticeAt: true,
+      }),
+    );
+
+    return {
+      markedAsSeenAt: seenAt.toISOString(),
+      previousLastSeenNoticesAt,
+    };
   }
 }

--- a/src/api/notice/services/notice.service.ts
+++ b/src/api/notice/services/notice.service.ts
@@ -1,8 +1,28 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { MoreThan, Repository } from 'typeorm';
-import { Notice } from '../entities/notice.entity';
+import { Notice, NoticeWhatsappDeliveryStatus } from '../entities/notice.entity';
 import { NoticeReadState } from '../entities/notice-read-state.entity';
+import { CreateNoticeDto } from '../dto/create-notice.dto';
+import { UpdateNoticeDto } from '../dto/update-notice.dto';
+
+class WhatsappSendError extends Error {
+  constructor(
+    message: string,
+    readonly options: { retryable: boolean; statusCode?: number; code?: string },
+  ) {
+    super(message);
+  }
+}
+
+interface EvolutionSendResponse {
+  key?: { id?: string };
+  id?: string;
+  message?: {
+    key?: { id?: string };
+  };
+}
 
 @Injectable()
 export class NoticeService {
@@ -13,11 +33,26 @@ export class NoticeService {
     private readonly noticeRepository: Repository<Notice>,
     @InjectRepository(NoticeReadState)
     private readonly noticeReadStateRepository: Repository<NoticeReadState>,
+    private readonly configService: ConfigService,
   ) {}
 
-  async create(data: Partial<Notice>, organizationId: string): Promise<Notice> {
-    const notice = this.noticeRepository.create({ ...data, organizationId });
-    return this.noticeRepository.save(notice);
+  async create(data: CreateNoticeDto, organizationId: string): Promise<Notice> {
+    const shouldSendViaWhatsapp = Boolean(data.sendViaWhatsapp);
+
+    const notice = this.noticeRepository.create({
+      ...data,
+      organizationId,
+      sendViaWhatsapp: shouldSendViaWhatsapp,
+      whatsappDeliveryStatus: shouldSendViaWhatsapp ? 'pending' : 'not_requested',
+    });
+
+    const savedNotice = await this.noticeRepository.save(notice);
+
+    if (!shouldSendViaWhatsapp) {
+      return savedNotice;
+    }
+
+    return this.dispatchNoticeViaWhatsapp(savedNotice.id, organizationId);
   }
 
   async findAll(
@@ -34,7 +69,7 @@ export class NoticeService {
     return { data, total };
   }
 
-  async update(id: string, data: Partial<Notice>, organizationId: string): Promise<Notice> {
+  async update(id: string, data: UpdateNoticeDto, organizationId: string): Promise<Notice> {
     const notice = await this.noticeRepository.findOne({ where: { id, organizationId } });
     if (!notice) {
       throw new NotFoundException('Notice not found');
@@ -127,5 +162,277 @@ export class NoticeService {
       markedAsSeenAt: seenAt.toISOString(),
       previousLastSeenNoticesAt,
     };
+  }
+
+  private async dispatchNoticeViaWhatsapp(noticeId: string, organizationId: string): Promise<Notice> {
+    const notice = await this.noticeRepository.findOne({ where: { id: noticeId, organizationId } });
+
+    if (!notice) {
+      throw new NotFoundException('Notice not found');
+    }
+
+    if (!notice.sendViaWhatsapp) {
+      return notice;
+    }
+
+    if (notice.whatsappDeliveryStatus === 'sent' && notice.whatsappProviderMessageId) {
+      this.logger.log(
+        JSON.stringify({
+          event: 'notice_whatsapp_send_skipped_already_sent',
+          noticeId: notice.id,
+          organizationId,
+          providerMessageId: notice.whatsappProviderMessageId,
+        }),
+      );
+      return notice;
+    }
+
+    const groupJid = this.resolveOrganizationGroupJid(organizationId);
+    if (!groupJid) {
+      return this.persistWhatsappFailure(notice, {
+        status: 'skipped',
+        error: 'WhatsApp group is not configured for this organization',
+        retryable: false,
+      });
+    }
+
+    const baseUrl = this.configService.get<string>('WHATSAPP_EVOLUTION_BASE_URL')?.trim();
+    const instance = this.configService.get<string>('WHATSAPP_EVOLUTION_INSTANCE')?.trim();
+    const apiKey = this.configService.get<string>('WHATSAPP_EVOLUTION_API_KEY')?.trim();
+
+    if (!baseUrl || !instance || !apiKey) {
+      return this.persistWhatsappFailure(notice, {
+        status: 'failed',
+        error: 'WhatsApp provider credentials are not configured',
+        retryable: false,
+      });
+    }
+
+    const maxAttempts = this.readPositiveIntEnv('WHATSAPP_SEND_MAX_ATTEMPTS', 3);
+    const baseBackoffMs = this.readPositiveIntEnv('WHATSAPP_SEND_BASE_BACKOFF_MS', 250);
+
+    let current = notice;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      current = await this.noticeRepository.save({
+        ...current,
+        whatsappAttemptCount: attempt,
+        whatsappLastAttemptAt: new Date(),
+        whatsappDeliveryStatus: attempt === 1 ? 'pending' : 'retrying',
+      });
+
+      try {
+        const providerResult = await this.sendToEvolutionApi({
+          notice: current,
+          baseUrl,
+          instance,
+          apiKey,
+          groupJid,
+        });
+
+        const sentNotice = await this.noticeRepository.save({
+          ...current,
+          whatsappDeliveryStatus: 'sent',
+          whatsappSentAt: new Date(),
+          whatsappProviderMessageId: providerResult.providerMessageId,
+          whatsappLastError: null,
+        });
+
+        this.logger.log(
+          JSON.stringify({
+            event: 'notice_whatsapp_send_succeeded',
+            noticeId: sentNotice.id,
+            organizationId,
+            attempt,
+            providerMessageId: sentNotice.whatsappProviderMessageId,
+          }),
+        );
+
+        return sentNotice;
+      } catch (error) {
+        const failure = error as WhatsappSendError;
+        const canRetry = failure.options.retryable && attempt < maxAttempts;
+
+        this.logger.warn(
+          JSON.stringify({
+            event: 'notice_whatsapp_send_failed',
+            noticeId: current.id,
+            organizationId,
+            attempt,
+            willRetry: canRetry,
+            statusCode: failure.options.statusCode,
+            code: failure.options.code,
+            message: failure.message,
+          }),
+        );
+
+        current = await this.noticeRepository.save({
+          ...current,
+          whatsappDeliveryStatus: canRetry ? 'retrying' : 'failed',
+          whatsappLastError: this.trimError(
+            `${failure.message}${failure.options.statusCode ? ` [status=${failure.options.statusCode}]` : ''}${
+              failure.options.code ? ` [code=${failure.options.code}]` : ''
+            }`,
+          ),
+        });
+
+        if (!canRetry) {
+          return current;
+        }
+
+        await this.sleep(baseBackoffMs * 2 ** (attempt - 1));
+      }
+    }
+
+    return current;
+  }
+
+  private async sendToEvolutionApi(params: {
+    notice: Notice;
+    baseUrl: string;
+    instance: string;
+    apiKey: string;
+    groupJid: string;
+  }): Promise<{ providerMessageId: string | null }> {
+    const endpoint = `${params.baseUrl.replace(/\/+$/, '')}/message/sendText/${encodeURIComponent(params.instance)}`;
+    const timeoutMs = this.readPositiveIntEnv('WHATSAPP_SEND_TIMEOUT_MS', 8000);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    const message = this.composeNoticeMessage(params.notice);
+
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: params.apiKey,
+          'x-idempotency-key': params.notice.id,
+        },
+        body: JSON.stringify({
+          number: params.groupJid,
+          text: message,
+        }),
+        signal: controller.signal,
+      });
+
+      const responseBody = await this.readJsonSafe<EvolutionSendResponse>(response);
+      if (!response.ok) {
+        throw new WhatsappSendError('Provider rejected notice message', {
+          retryable: this.isRetryableStatus(response.status),
+          statusCode: response.status,
+        });
+      }
+
+      const providerMessageId =
+        responseBody?.key?.id ?? responseBody?.message?.key?.id ?? responseBody?.id ?? null;
+
+      return { providerMessageId };
+    } catch (error) {
+      if (error instanceof WhatsappSendError) {
+        throw error;
+      }
+
+      if ((error as Error).name === 'AbortError') {
+        throw new WhatsappSendError('Timeout sending notice to provider', { retryable: true, code: 'timeout' });
+      }
+
+      throw new WhatsappSendError((error as Error).message || 'Unknown WhatsApp send error', {
+        retryable: true,
+        code: 'network_error',
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private composeNoticeMessage(notice: Notice): string {
+    const chunks = [
+      `*${notice.title.trim()}*`,
+      notice.subtitle?.trim() ? `_${notice.subtitle.trim()}_` : '',
+      notice.content.trim(),
+    ].filter(Boolean);
+
+    return chunks.join('\n\n');
+  }
+
+  private resolveOrganizationGroupJid(organizationId: string): string | null {
+    const mappingJson = this.configService.get<string>('WHATSAPP_GROUP_JID_BY_ORG')?.trim();
+    if (!mappingJson) {
+      return null;
+    }
+
+    try {
+      const parsed = JSON.parse(mappingJson) as Record<string, string>;
+      const raw = parsed?.[organizationId];
+      return raw?.trim() || null;
+    } catch {
+      this.logger.error(
+        JSON.stringify({
+          event: 'notice_whatsapp_group_mapping_invalid',
+          organizationId,
+        }),
+      );
+      return null;
+    }
+  }
+
+  private async persistWhatsappFailure(
+    notice: Notice,
+    details: { status: NoticeWhatsappDeliveryStatus; error: string; retryable: boolean },
+  ): Promise<Notice> {
+    const failedNotice = await this.noticeRepository.save({
+      ...notice,
+      whatsappDeliveryStatus: details.status,
+      whatsappLastError: this.trimError(details.error),
+    });
+
+    this.logger.warn(
+      JSON.stringify({
+        event: 'notice_whatsapp_send_not_attempted',
+        noticeId: notice.id,
+        organizationId: notice.organizationId,
+        status: details.status,
+        retryable: details.retryable,
+        reason: details.error,
+      }),
+    );
+
+    return failedNotice;
+  }
+
+  private readPositiveIntEnv(name: string, fallback: number): number {
+    const value = this.configService.get<string>(name);
+    if (!value) {
+      return fallback;
+    }
+
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+
+  private isRetryableStatus(status: number): boolean {
+    return [408, 409, 425, 429, 500, 502, 503, 504].includes(status);
+  }
+
+  private trimError(value: string): string {
+    return value.slice(0, 900);
+  }
+
+  private async readJsonSafe<T>(response: Response): Promise<T | null> {
+    const bodyText = await response.text();
+    if (!bodyText) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(bodyText) as T;
+    } catch {
+      return null;
+    }
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 }

--- a/src/migration/1762900000000-AddNoticeReadState.ts
+++ b/src/migration/1762900000000-AddNoticeReadState.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddNoticeReadState1762900000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "notice_read_state" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "userId" uuid NOT NULL,
+        "organizationId" uuid NOT NULL,
+        "lastSeenNoticesAt" timestamp NULL,
+        "createdAt" timestamp NOT NULL DEFAULT now(),
+        "updatedAt" timestamp NOT NULL DEFAULT now()
+      )
+    `);
+
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conname = 'UQ_notice_read_state_user_org'
+        ) THEN
+          ALTER TABLE "notice_read_state"
+          ADD CONSTRAINT "UQ_notice_read_state_user_org" UNIQUE ("userId", "organizationId");
+        END IF;
+      END $$;
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_notice_read_state_org_user"
+      ON "notice_read_state" ("organizationId", "userId")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_notice_org_created_at"
+      ON "notice" ("organizationId", "createdAt")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_notice_org_created_at"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_notice_read_state_org_user"`);
+    await queryRunner.query(`ALTER TABLE "notice_read_state" DROP CONSTRAINT IF EXISTS "UQ_notice_read_state_user_org"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "notice_read_state"`);
+  }
+}

--- a/src/migration/1763000000000-AddSendViaWhatsappToNotice.ts
+++ b/src/migration/1763000000000-AddSendViaWhatsappToNotice.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSendViaWhatsappToNotice1763000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "notice"
+      ADD COLUMN IF NOT EXISTS "sendViaWhatsapp" boolean NOT NULL DEFAULT false
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "notice"
+      DROP COLUMN IF EXISTS "sendViaWhatsapp"
+    `);
+  }
+}

--- a/src/migration/1763100000000-AddNoticeWhatsappDeliveryState.ts
+++ b/src/migration/1763100000000-AddNoticeWhatsappDeliveryState.ts
@@ -1,0 +1,46 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddNoticeWhatsappDeliveryState1763100000000 implements MigrationInterface {
+  name = 'AddNoticeWhatsappDeliveryState1763100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "notice"
+      ADD COLUMN IF NOT EXISTS "whatsappDeliveryStatus" varchar(32) NOT NULL DEFAULT 'not_requested'
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "notice"
+      ADD COLUMN IF NOT EXISTS "whatsappAttemptCount" integer NOT NULL DEFAULT 0
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "notice"
+      ADD COLUMN IF NOT EXISTS "whatsappLastAttemptAt" timestamp
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "notice"
+      ADD COLUMN IF NOT EXISTS "whatsappSentAt" timestamp
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "notice"
+      ADD COLUMN IF NOT EXISTS "whatsappProviderMessageId" varchar(128)
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "notice"
+      ADD COLUMN IF NOT EXISTS "whatsappLastError" text
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "notice" DROP COLUMN IF EXISTS "whatsappLastError"`);
+    await queryRunner.query(`ALTER TABLE "notice" DROP COLUMN IF EXISTS "whatsappProviderMessageId"`);
+    await queryRunner.query(`ALTER TABLE "notice" DROP COLUMN IF EXISTS "whatsappSentAt"`);
+    await queryRunner.query(`ALTER TABLE "notice" DROP COLUMN IF EXISTS "whatsappLastAttemptAt"`);
+    await queryRunner.query(`ALTER TABLE "notice" DROP COLUMN IF EXISTS "whatsappAttemptCount"`);
+    await queryRunner.query(`ALTER TABLE "notice" DROP COLUMN IF EXISTS "whatsappDeliveryStatus"`);
+  }
+}


### PR DESCRIPTION
This pull request introduces two major features to the notice system: (1) per-user notice read state tracking, enabling users to see how many notices are unread and to mark all as read, and (2) support for WhatsApp delivery status tracking on notices. It includes the necessary backend logic, database migrations, controller endpoints, and comprehensive tests for these new capabilities.

**Notice Read State Tracking**

* Adds a new entity `NoticeReadState` and associated migration to track, per user and organization, the timestamp of the last seen notice. This enables accurate unread notice counts and "mark all as seen" functionality. [[1]](diffhunk://#diff-43dcde6ea83bde4888668be56a4f1bf31d4793b8481ffa92a849d0eca2dd0e72R1-R24) [[2]](diffhunk://#diff-ecb35415dfeb0b36110e405f1c709b2bbb217b698b4ab4a026d7b57ffc5ea6ffR1-R44)
* Implements two new endpoints in `NoticeController`: `GET /unread-count` returns the user's unread notice count and last seen timestamp; `POST /mark-seen` marks all notices as seen for the user.
* Updates `NoticeService` to support fetching unread counts and marking all as seen, including logic for first-time and repeat operations, and adds logging for these events. [[1]](diffhunk://#diff-e5ed293b4fac9a8ca410a2d2114a080bd0f79cc14a79a8732926dcce6c647ab2L1-R15) [[2]](diffhunk://#diff-e5ed293b4fac9a8ca410a2d2114a080bd0f79cc14a79a8732926dcce6c647ab2R52-R130)
* Adds unit tests for both the controller and service to ensure correct behavior for unread count and mark-as-seen operations. [[1]](diffhunk://#diff-fb4104ab0eb5d8985b4bf75b93b7b41e47d089573013c114290fddf16016ddbcR1-R68) [[2]](diffhunk://#diff-b8e5297bfbfb2269593090c31c25743e2a477f4585c82b9a7394cc791afdf24cR1-R99)
* Registers the new entity with the module for dependency injection.

**WhatsApp Delivery Status Tracking**

* Extends the `Notice` entity and database schema with fields for WhatsApp delivery status, attempt count, timestamps, provider message ID, and last error, supporting future integration with WhatsApp delivery workflows. [[1]](diffhunk://#diff-b52a328ae8bcd724db68bbb39baf59bad9cf5b456d6b4ba9cbf07378d183a818R3-R10) [[2]](diffhunk://#diff-b52a328ae8bcd724db68bbb39baf59bad9cf5b456d6b4ba9cbf07378d183a818R25-R45) [[3]](diffhunk://#diff-949ad062dcd6633342af33bffef3e46f0abc0077dd6fccd1e033a101b67d7824R1-R17) [[4]](diffhunk://#diff-2d15f23ac58b843f50f7b8b393287e5fee9530fcda920440d277634b1ddf1c24R1-R46)

These changes lay the groundwork for user-specific notice tracking and external delivery integrations, with robust test coverage and database migrations.

**References:**  
[[1]](diffhunk://#diff-43dcde6ea83bde4888668be56a4f1bf31d4793b8481ffa92a849d0eca2dd0e72R1-R24) [[2]](diffhunk://#diff-ecb35415dfeb0b36110e405f1c709b2bbb217b698b4ab4a026d7b57ffc5ea6ffR1-R44) [[3]](diffhunk://#diff-3cff6fa09db7d4a307b606f97166e4a3514811e82a4bd4ae62d035348ad4862bR36-R49) [[4]](diffhunk://#diff-e5ed293b4fac9a8ca410a2d2114a080bd0f79cc14a79a8732926dcce6c647ab2L1-R15) [[5]](diffhunk://#diff-e5ed293b4fac9a8ca410a2d2114a080bd0f79cc14a79a8732926dcce6c647ab2R52-R130) [[6]](diffhunk://#diff-fb4104ab0eb5d8985b4bf75b93b7b41e47d089573013c114290fddf16016ddbcR1-R68) [[7]](diffhunk://#diff-b8e5297bfbfb2269593090c31c25743e2a477f4585c82b9a7394cc791afdf24cR1-R99) [[8]](diffhunk://#diff-67cc89e3f026dc73d0d59f2800bd5bafdb45fbc36a4548c902672b8fde81fc11R6-R10) [[9]](diffhunk://#diff-b52a328ae8bcd724db68bbb39baf59bad9cf5b456d6b4ba9cbf07378d183a818R3-R10) [[10]](diffhunk://#diff-b52a328ae8bcd724db68bbb39baf59bad9cf5b456d6b4ba9cbf07378d183a818R25-R45) [[11]](diffhunk://#diff-949ad062dcd6633342af33bffef3e46f0abc0077dd6fccd1e033a101b67d7824R1-R17) [[12]](diffhunk://#diff-2d15f23ac58b843f50f7b8b393287e5fee9530fcda920440d277634b1ddf1c24R1-R46)…add notice read state entity and migrations