### PR TITLE
Update start script for database deployment in production

### DIFF
--- a/deploy/evolution/railway/start-evolution.sh
+++ b/deploy/evolution/railway/start-evolution.sh
@@ -9,5 +9,9 @@ export PORT="${SERVER_PORT}"
 
 echo "[railway-evolution] starting with SERVER_HOST=${SERVER_HOST} SERVER_PORT=${SERVER_PORT}"
 
-# Evolution image already has dependencies and scripts.
-exec npm run start
+# Evolution image is built for production runtime. Use deploy+migrate then start:prod.
+if npm run | grep -q "db:deploy"; then
+  npm run db:deploy
+fi
+
+exec npm run start:prod


### PR DESCRIPTION
This pull request updates the startup script for the Evolution service to better align with production best practices. The script now conditionally runs database migrations before starting the production server, ensuring that the database is up-to-date when the service starts.

Startup process improvements:

* Updated `deploy/evolution/railway/start-evolution.sh` to run `npm run db:deploy` if the script is available, ensuring database migrations are applied before starting the service. The script now starts the server with `npm run start:prod` instead of `npm run start`.…efore starting production