### PR TITLE
Implement inbound email reply processing with token-based threading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,10 @@ WHATSAPP_GROUP_JID_BY_ORG={"your-organization-uuid":"120363xxxxxxxxxxxx@g.us"}
 WHATSAPP_SEND_MAX_ATTEMPTS=3
 WHATSAPP_SEND_BASE_BACKOFF_MS=250
 WHATSAPP_SEND_TIMEOUT_MS=8000
+
+# Inbound email reply threading
+CONTACT_EMAIL_INBOUND_SECRET=replace_with_strong_random_secret
+CONTACT_EMAIL_REPLY_TOKEN_SECRET=replace_with_strong_random_secret
+CONTACT_EMAIL_REPLY_TOKEN_TTL_HOURS=720
+# Optional explicit mailbox base address used for VERP-style reply-to, e.g. faleconosco@example.com
+CONTACT_EMAIL_REPLY_BASE_ADDRESS=faleconosco@example.com

--- a/.env.example
+++ b/.env.example
@@ -40,5 +40,5 @@ WHATSAPP_SEND_TIMEOUT_MS=8000
 CONTACT_EMAIL_INBOUND_SECRET=replace_with_strong_random_secret
 CONTACT_EMAIL_REPLY_TOKEN_SECRET=replace_with_strong_random_secret
 CONTACT_EMAIL_REPLY_TOKEN_TTL_HOURS=720
-# Optional explicit mailbox base address used for VERP-style reply-to, e.g. faleconosco@example.com
+# Required mailbox base address used for VERP-style reply-to, e.g. faleconosco@example.com
 CONTACT_EMAIL_REPLY_BASE_ADDRESS=faleconosco@example.com

--- a/README.md
+++ b/README.md
@@ -65,6 +65,22 @@ $ npm run test:cov
 - `GET /messages/unread-count`: Contador de não lidas.
 - `POST /messages/:id/mark-read`: Marca mensagem como lida.
 - `POST /messages/:id/replies`: Responde mensagem.
+- `POST /messages/inbound/email`: Ingestão de resposta por email (thread por headers + fallback por token assinado no plus-address).
+
+### Threading de Email Inbound (Contato)
+
+- Estratégia de resolução:
+  1. `In-Reply-To` / `References` (IDs de thread do provider).
+  2. Fallback por token assinado em `Reply-To` no formato `faleconosco+grillrent.<token>@dominio`.
+- Segurança:
+  - Token HMAC-SHA256 com `CONTACT_EMAIL_REPLY_TOKEN_SECRET`.
+  - Expiração via `CONTACT_EMAIL_REPLY_TOKEN_TTL_HOURS` (ex: `720`).
+  - Validação estrita do remetente (`fromEmail`) contra o morador esperado.
+- Razões de recusa explícitas:
+  - `thread_not_found`
+  - `invalid_reply_token`
+  - `sender_mismatch`
+  - `duplicate_external_message`
 
 ### Configuração WhatsApp
 - `GET /whatsapp/settings`: Lê settings por organização.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ $ npm run test:cov
 - Segurança:
   - Token HMAC-SHA256 com `CONTACT_EMAIL_REPLY_TOKEN_SECRET`.
   - Expiração via `CONTACT_EMAIL_REPLY_TOKEN_TTL_HOURS` (ex: `720`).
+  - Base de reply-to obrigatório em `CONTACT_EMAIL_REPLY_BASE_ADDRESS`.
   - Validação estrita do remetente (`fromEmail`) contra o morador esperado.
 - Razões de recusa explícitas:
   - `thread_not_found`

--- a/src/api/message/dto/ingest-inbound-email-reply.dto.ts
+++ b/src/api/message/dto/ingest-inbound-email-reply.dto.ts
@@ -1,21 +1,29 @@
 import * as Joi from '@hapi/joi';
 
 export const IngestInboundEmailReplySchema = Joi.object({
-  organizationId: Joi.string().uuid().required(),
-  messageId: Joi.string().uuid().required(),
+  organizationId: Joi.string().uuid().optional(),
+  messageId: Joi.string().uuid().optional(),
   fromEmail: Joi.string().trim().email().max(150).required(),
   content: Joi.string().trim().max(10000).required(),
   externalMessageId: Joi.string().trim().max(255).allow('', null).optional(),
   subject: Joi.string().trim().max(255).allow('', null).optional(),
   receivedAt: Joi.date().iso().optional(),
+  threadMessageIds: Joi.array().items(Joi.string().trim().max(255)).max(50).optional(),
+  toRecipients: Joi.array().items(Joi.string().trim().max(320)).max(50).optional(),
+  deliveredToRecipients: Joi.array().items(Joi.string().trim().max(320)).max(50).optional(),
+  xOriginalToRecipients: Joi.array().items(Joi.string().trim().max(320)).max(50).optional(),
 });
 
 export class IngestInboundEmailReplyDto {
-  organizationId!: string;
-  messageId!: string;
+  organizationId?: string;
+  messageId?: string;
   fromEmail!: string;
   content!: string;
   externalMessageId?: string | null;
   subject?: string | null;
   receivedAt?: string;
+  threadMessageIds?: string[];
+  toRecipients?: string[];
+  deliveredToRecipients?: string[];
+  xOriginalToRecipients?: string[];
 }

--- a/src/api/message/message.module.ts
+++ b/src/api/message/message.module.ts
@@ -7,6 +7,7 @@ import { MessageReply } from './entities/message-reply.entity';
 import { OrganizationContactEmailSettings } from './entities/organization-contact-email-settings.entity';
 import { MessageService } from './services/message.service';
 import { ContactEmailSettingsService } from './services/contact-email-settings.service';
+import { EmailReplyTokenService } from './services/email-reply-token.service';
 import { User } from '../user/entities/user.entity';
 import { EmailModule } from '../../shared/email/email.module';
 import { UserModule } from '../user/user.module';
@@ -14,7 +15,7 @@ import { UserModule } from '../user/user.module';
 @Module({
   imports: [TypeOrmModule.forFeature([Message, MessageReply, User, OrganizationContactEmailSettings]), EmailModule, UserModule],
   controllers: [MessageController, ContactEmailSettingsController],
-  providers: [MessageService, ContactEmailSettingsService],
-  exports: [MessageService, ContactEmailSettingsService],
+  providers: [MessageService, ContactEmailSettingsService, EmailReplyTokenService],
+  exports: [MessageService, ContactEmailSettingsService, EmailReplyTokenService],
 })
 export class MessageModule {}

--- a/src/api/message/services/email-reply-token.service.spec.ts
+++ b/src/api/message/services/email-reply-token.service.spec.ts
@@ -18,30 +18,43 @@ describe('EmailReplyTokenService', () => {
   });
 
   it('generates and verifies reply token', () => {
+    const messageId = '11111111-1111-4111-8111-111111111111';
+    const organizationId = '22222222-2222-4222-8222-222222222222';
+    const senderEmail = 'Resident@Example.com';
     const token = service.generateReplyToken({
-      messageId: '11111111-1111-4111-8111-111111111111',
-      organizationId: '22222222-2222-4222-8222-222222222222',
-      senderEmail: 'Resident@Example.com',
+      messageId,
+      organizationId,
+      senderEmail,
     });
 
-    const verification = service.verifyReplyToken(token);
-    expect(verification.valid).toBe(true);
-    if (!verification.valid) return;
+    expect(token.length).toBeLessThanOrEqual(43);
+    const decoded = service.verifyReplyToken(token);
+    expect(decoded.valid).toBe(true);
+    if (!decoded.valid) return;
+    expect(decoded.payload.messageId).toBe(messageId);
 
-    expect(verification.payload.messageId).toBe('11111111-1111-4111-8111-111111111111');
-    expect(verification.payload.organizationId).toBe('22222222-2222-4222-8222-222222222222');
-    expect(verification.payload.senderEmail).toBe('resident@example.com');
+    const verification = service.verifyCompactTokenAgainstContext(token, {
+      organizationId,
+      senderEmail,
+    });
+    expect(verification).toEqual({ valid: true, messageId });
   });
 
   it('rejects tampered token', () => {
+    const messageId = '11111111-1111-4111-8111-111111111111';
+    const organizationId = '22222222-2222-4222-8222-222222222222';
+    const senderEmail = 'resident@example.com';
     const token = service.generateReplyToken({
-      messageId: '11111111-1111-4111-8111-111111111111',
-      organizationId: '22222222-2222-4222-8222-222222222222',
-      senderEmail: 'resident@example.com',
+      messageId,
+      organizationId,
+      senderEmail,
     });
 
     const tampered = `${token.slice(0, -1)}x`;
-    const verification = service.verifyReplyToken(tampered);
+    const verification = service.verifyCompactTokenAgainstContext(tampered, {
+      organizationId,
+      senderEmail,
+    });
     expect(verification).toEqual({ valid: false, reason: 'invalid' });
   });
 
@@ -67,5 +80,6 @@ describe('EmailReplyTokenService', () => {
 
     expect(replyAddress.startsWith('faleconosco+grillrent.')).toBe(true);
     expect(service.extractTokenFromReplyAddress(replyAddress)).toBe(token);
+    expect(service.extractTokenFromReplyAddress(`"Contact" <${replyAddress}>`)).toBe(token);
   });
 });

--- a/src/api/message/services/email-reply-token.service.spec.ts
+++ b/src/api/message/services/email-reply-token.service.spec.ts
@@ -1,0 +1,71 @@
+import { ConfigService } from '@nestjs/config';
+import { EmailReplyTokenService } from './email-reply-token.service';
+
+describe('EmailReplyTokenService', () => {
+  let service: EmailReplyTokenService;
+  let configService: { get: jest.Mock };
+
+  beforeEach(() => {
+    configService = {
+      get: jest.fn((key: string) => {
+        if (key === 'CONTACT_EMAIL_REPLY_TOKEN_SECRET') return 'token-secret';
+        if (key === 'CONTACT_EMAIL_REPLY_TOKEN_TTL_HOURS') return '720';
+        return null;
+      }),
+    };
+
+    service = new EmailReplyTokenService(configService as unknown as ConfigService);
+  });
+
+  it('generates and verifies reply token', () => {
+    const token = service.generateReplyToken({
+      messageId: '11111111-1111-4111-8111-111111111111',
+      organizationId: '22222222-2222-4222-8222-222222222222',
+      senderEmail: 'Resident@Example.com',
+    });
+
+    const verification = service.verifyReplyToken(token);
+    expect(verification.valid).toBe(true);
+    if (!verification.valid) return;
+
+    expect(verification.payload.messageId).toBe('11111111-1111-4111-8111-111111111111');
+    expect(verification.payload.organizationId).toBe('22222222-2222-4222-8222-222222222222');
+    expect(verification.payload.senderEmail).toBe('resident@example.com');
+  });
+
+  it('rejects tampered token', () => {
+    const token = service.generateReplyToken({
+      messageId: '11111111-1111-4111-8111-111111111111',
+      organizationId: '22222222-2222-4222-8222-222222222222',
+      senderEmail: 'resident@example.com',
+    });
+
+    const tampered = `${token.slice(0, -1)}x`;
+    const verification = service.verifyReplyToken(tampered);
+    expect(verification).toEqual({ valid: false, reason: 'invalid' });
+  });
+
+  it('rejects expired token', () => {
+    const token = service.generateReplyToken({
+      messageId: '11111111-1111-4111-8111-111111111111',
+      organizationId: '22222222-2222-4222-8222-222222222222',
+      senderEmail: 'resident@example.com',
+      exp: Math.floor(Date.now() / 1000) - 10,
+    });
+
+    const verification = service.verifyReplyToken(token);
+    expect(verification).toEqual({ valid: false, reason: 'expired' });
+  });
+
+  it('builds and extracts token from plus-address', () => {
+    const token = service.generateReplyToken({
+      messageId: '11111111-1111-4111-8111-111111111111',
+      organizationId: '22222222-2222-4222-8222-222222222222',
+      senderEmail: 'resident@example.com',
+    });
+    const replyAddress = service.buildReplyToAddress('faleconosco@example.com', token);
+
+    expect(replyAddress.startsWith('faleconosco+grillrent.')).toBe(true);
+    expect(service.extractTokenFromReplyAddress(replyAddress)).toBe(token);
+  });
+});

--- a/src/api/message/services/email-reply-token.service.ts
+++ b/src/api/message/services/email-reply-token.service.ts
@@ -3,12 +3,20 @@ import { ConfigService } from '@nestjs/config';
 import { createHmac, timingSafeEqual } from 'crypto';
 
 const DEFAULT_TTL_HOURS = 720;
+const COMPACT_TOKEN_MAC_BYTES_LENGTH = 10;
+const COMPACT_TOKEN_BYTES_LENGTH = 16 + 4 + COMPACT_TOKEN_MAC_BYTES_LENGTH;
 
 export interface EmailReplyTokenPayload {
   messageId: string;
   organizationId: string;
   senderEmail: string;
   exp: number;
+}
+
+interface CompactReplyTokenPayload {
+  messageId: string;
+  exp: number;
+  mac: Buffer;
 }
 
 type EmailReplyTokenVerificationResult =
@@ -25,20 +33,44 @@ export class EmailReplyTokenService {
     senderEmail: string;
     exp?: number;
   }): string {
-    const payload: EmailReplyTokenPayload = {
+    const normalizedSenderEmail = input.senderEmail.trim().toLowerCase();
+    const exp = input.exp ?? this.resolveDefaultExpirationEpochSeconds();
+    const messageIdBytes = this.uuidToBytes(input.messageId);
+    const expBytes = Buffer.alloc(4);
+    expBytes.writeUInt32BE(exp, 0);
+    const mac = this.computeCompactMac({
       messageId: input.messageId,
       organizationId: input.organizationId,
-      senderEmail: input.senderEmail.trim().toLowerCase(),
-      exp: input.exp ?? this.resolveDefaultExpirationEpochSeconds(),
-    };
+      senderEmail: normalizedSenderEmail,
+      exp,
+    });
 
-    const encodedPayload = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
-    const signature = this.sign(encodedPayload);
-    return `${encodedPayload}.${signature}`;
+    const tokenBytes = Buffer.concat([messageIdBytes, expBytes, mac]);
+    return tokenBytes.toString('base64url');
   }
 
   verifyReplyToken(token: string): EmailReplyTokenVerificationResult {
     const normalizedToken = token.trim();
+    const compact = this.decodeCompactReplyToken(normalizedToken);
+    if (compact.valid) {
+      return {
+        valid: true,
+        payload: {
+          messageId: compact.payload.messageId,
+          organizationId: '',
+          senderEmail: '',
+          exp: compact.payload.exp,
+        },
+      };
+    }
+    if (compact.reason === 'expired') {
+      return { valid: false, reason: 'expired' };
+    }
+    if (!normalizedToken.includes('.')) {
+      return { valid: false, reason: 'invalid' };
+    }
+
+    // Legacy format support for already-sent outbound emails.
     const split = normalizedToken.split('.');
     if (split.length !== 2) {
       return { valid: false, reason: 'invalid' };
@@ -85,27 +117,59 @@ export class EmailReplyTokenService {
       throw new Error('Invalid reply mailbox address');
     }
 
-    const encodedToken = Buffer.from(token, 'utf8').toString('base64url');
-    return `${localPart}+grillrent.${encodedToken}@${domain}`;
+    const plusLocalPart = `${localPart}+grillrent.${token}`;
+    if (plusLocalPart.length > 64) {
+      throw new Error('Reply token local-part exceeds 64 characters');
+    }
+
+    return `${plusLocalPart}@${domain}`;
   }
 
   extractTokenFromReplyAddress(address: string): string | null {
-    const normalizedAddress = address.trim();
-    const [localPart] = normalizedAddress.split('@');
+    const mailbox = this.extractMailboxAddress(address);
+    if (!mailbox) {
+      return null;
+    }
+
+    const atIndex = mailbox.lastIndexOf('@');
+    if (atIndex === -1) {
+      return null;
+    }
+
+    const localPart = mailbox.slice(0, atIndex);
     if (!localPart) {
       return null;
     }
 
-    const match = localPart.match(/\+grillrent\.([A-Za-z0-9_-]+)$/);
+    const match = localPart.match(/\+grillrent\.([A-Za-z0-9._-]+)$/i);
     if (!match?.[1]) {
       return null;
     }
 
-    try {
-      return Buffer.from(match[1], 'base64url').toString('utf8');
-    } catch {
-      return null;
+    return match[1];
+  }
+
+  verifyCompactTokenAgainstContext(
+    token: string,
+    context: { organizationId: string; senderEmail: string },
+  ): { valid: true; messageId: string } | { valid: false; reason: 'invalid' | 'expired' } {
+    const decoded = this.decodeCompactReplyToken(token);
+    if (!decoded.valid) {
+      return decoded;
     }
+
+    const expectedMac = this.computeCompactMac({
+      messageId: decoded.payload.messageId,
+      organizationId: context.organizationId,
+      senderEmail: context.senderEmail.trim().toLowerCase(),
+      exp: decoded.payload.exp,
+    });
+
+    if (!this.buffersEqual(expectedMac, decoded.payload.mac)) {
+      return { valid: false, reason: 'invalid' };
+    }
+
+    return { valid: true, messageId: decoded.payload.messageId };
   }
 
   private sign(payload: string): string {
@@ -117,10 +181,14 @@ export class EmailReplyTokenService {
   private signaturesEqual(expected: string, provided: string): boolean {
     const expectedBuffer = Buffer.from(expected, 'utf8');
     const providedBuffer = Buffer.from(provided, 'utf8');
-    if (expectedBuffer.length !== providedBuffer.length) {
+    return this.buffersEqual(expectedBuffer, providedBuffer);
+  }
+
+  private buffersEqual(expected: Buffer, provided: Buffer): boolean {
+    if (expected.length !== provided.length) {
       return false;
     }
-    return timingSafeEqual(expectedBuffer, providedBuffer);
+    return timingSafeEqual(expected, provided);
   }
 
   private resolveSecret(): string {
@@ -157,5 +225,99 @@ export class EmailReplyTokenService {
       && typeof candidate.exp === 'number'
       && Number.isFinite(candidate.exp)
     );
+  }
+
+  private decodeCompactReplyToken(
+    token: string,
+  ): { valid: true; payload: CompactReplyTokenPayload } | { valid: false; reason: 'invalid' | 'expired' } {
+    let tokenBytes: Buffer;
+    try {
+      tokenBytes = Buffer.from(token, 'base64url');
+    } catch {
+      return { valid: false, reason: 'invalid' };
+    }
+
+    if (tokenBytes.length !== COMPACT_TOKEN_BYTES_LENGTH) {
+      return { valid: false, reason: 'invalid' };
+    }
+
+    const messageIdBytes = tokenBytes.subarray(0, 16);
+    const expBytes = tokenBytes.subarray(16, 20);
+    const mac = tokenBytes.subarray(20, 20 + COMPACT_TOKEN_MAC_BYTES_LENGTH);
+
+    const exp = expBytes.readUInt32BE(0);
+    if (exp <= Math.floor(Date.now() / 1000)) {
+      return { valid: false, reason: 'expired' };
+    }
+
+    let messageId: string;
+    try {
+      messageId = this.bytesToUuid(messageIdBytes);
+    } catch {
+      return { valid: false, reason: 'invalid' };
+    }
+
+    return {
+      valid: true,
+      payload: {
+        messageId,
+        exp,
+        mac,
+      },
+    };
+  }
+
+  private computeCompactMac(input: {
+    messageId: string;
+    organizationId: string;
+    senderEmail: string;
+    exp: number;
+  }): Buffer {
+    const body = `${input.messageId}|${input.organizationId}|${input.senderEmail}|${input.exp}`;
+    return createHmac('sha256', this.resolveSecret())
+      .update(body, 'utf8')
+      .digest()
+      .subarray(0, COMPACT_TOKEN_MAC_BYTES_LENGTH);
+  }
+
+  private uuidToBytes(value: string): Buffer {
+    const normalized = value.replace(/-/g, '');
+    if (!/^[0-9a-fA-F]{32}$/.test(normalized)) {
+      throw new Error('Invalid UUID');
+    }
+    return Buffer.from(normalized, 'hex');
+  }
+
+  private bytesToUuid(value: Buffer): string {
+    if (value.length !== 16) {
+      throw new Error('Invalid UUID bytes');
+    }
+    const hex = value.toString('hex');
+    return [
+      hex.slice(0, 8),
+      hex.slice(8, 12),
+      hex.slice(12, 16),
+      hex.slice(16, 20),
+      hex.slice(20, 32),
+    ].join('-');
+  }
+
+  private extractMailboxAddress(value: string): string | null {
+    const normalized = value.trim();
+    if (!normalized) {
+      return null;
+    }
+
+    const angleMatch = normalized.match(/<([^<>@\s]+@[^<>@\s]+)>/);
+    if (angleMatch?.[1]) {
+      return angleMatch[1].trim();
+    }
+
+    const mailboxMatch = normalized.match(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+/);
+    if (mailboxMatch?.[0]) {
+      return mailboxMatch[0].trim();
+    }
+
+    return null;
   }
 }

--- a/src/api/message/services/email-reply-token.service.ts
+++ b/src/api/message/services/email-reply-token.service.ts
@@ -1,0 +1,161 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHmac, timingSafeEqual } from 'crypto';
+
+const DEFAULT_TTL_HOURS = 720;
+
+export interface EmailReplyTokenPayload {
+  messageId: string;
+  organizationId: string;
+  senderEmail: string;
+  exp: number;
+}
+
+type EmailReplyTokenVerificationResult =
+  | { valid: true; payload: EmailReplyTokenPayload }
+  | { valid: false; reason: 'invalid' | 'expired' };
+
+@Injectable()
+export class EmailReplyTokenService {
+  constructor(private readonly configService: ConfigService) {}
+
+  generateReplyToken(input: {
+    messageId: string;
+    organizationId: string;
+    senderEmail: string;
+    exp?: number;
+  }): string {
+    const payload: EmailReplyTokenPayload = {
+      messageId: input.messageId,
+      organizationId: input.organizationId,
+      senderEmail: input.senderEmail.trim().toLowerCase(),
+      exp: input.exp ?? this.resolveDefaultExpirationEpochSeconds(),
+    };
+
+    const encodedPayload = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+    const signature = this.sign(encodedPayload);
+    return `${encodedPayload}.${signature}`;
+  }
+
+  verifyReplyToken(token: string): EmailReplyTokenVerificationResult {
+    const normalizedToken = token.trim();
+    const split = normalizedToken.split('.');
+    if (split.length !== 2) {
+      return { valid: false, reason: 'invalid' };
+    }
+
+    const [encodedPayload, providedSignature] = split;
+    if (!encodedPayload || !providedSignature) {
+      return { valid: false, reason: 'invalid' };
+    }
+
+    const expectedSignature = this.sign(encodedPayload);
+    if (!this.signaturesEqual(expectedSignature, providedSignature)) {
+      return { valid: false, reason: 'invalid' };
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8'));
+    } catch {
+      return { valid: false, reason: 'invalid' };
+    }
+
+    if (!this.isValidPayload(payload)) {
+      return { valid: false, reason: 'invalid' };
+    }
+
+    if (payload.exp <= Math.floor(Date.now() / 1000)) {
+      return { valid: false, reason: 'expired' };
+    }
+
+    return {
+      valid: true,
+      payload: {
+        ...payload,
+        senderEmail: payload.senderEmail.trim().toLowerCase(),
+      },
+    };
+  }
+
+  buildReplyToAddress(baseAddress: string, token: string): string {
+    const normalizedBaseAddress = baseAddress.trim().toLowerCase();
+    const [localPart, domain] = normalizedBaseAddress.split('@');
+    if (!localPart || !domain) {
+      throw new Error('Invalid reply mailbox address');
+    }
+
+    const encodedToken = Buffer.from(token, 'utf8').toString('base64url');
+    return `${localPart}+grillrent.${encodedToken}@${domain}`;
+  }
+
+  extractTokenFromReplyAddress(address: string): string | null {
+    const normalizedAddress = address.trim();
+    const [localPart] = normalizedAddress.split('@');
+    if (!localPart) {
+      return null;
+    }
+
+    const match = localPart.match(/\+grillrent\.([A-Za-z0-9_-]+)$/);
+    if (!match?.[1]) {
+      return null;
+    }
+
+    try {
+      return Buffer.from(match[1], 'base64url').toString('utf8');
+    } catch {
+      return null;
+    }
+  }
+
+  private sign(payload: string): string {
+    return createHmac('sha256', this.resolveSecret())
+      .update(payload, 'utf8')
+      .digest('base64url');
+  }
+
+  private signaturesEqual(expected: string, provided: string): boolean {
+    const expectedBuffer = Buffer.from(expected, 'utf8');
+    const providedBuffer = Buffer.from(provided, 'utf8');
+    if (expectedBuffer.length !== providedBuffer.length) {
+      return false;
+    }
+    return timingSafeEqual(expectedBuffer, providedBuffer);
+  }
+
+  private resolveSecret(): string {
+    const secret = (this.configService.get<string>('CONTACT_EMAIL_REPLY_TOKEN_SECRET') || '').trim();
+    if (!secret) {
+      throw new Error('CONTACT_EMAIL_REPLY_TOKEN_SECRET is required');
+    }
+    return secret;
+  }
+
+  private resolveDefaultExpirationEpochSeconds(): number {
+    const rawTtl = (this.configService.get<string>('CONTACT_EMAIL_REPLY_TOKEN_TTL_HOURS') || '').trim();
+    const ttlHours = rawTtl ? Number(rawTtl) : DEFAULT_TTL_HOURS;
+    if (!Number.isFinite(ttlHours) || ttlHours <= 0) {
+      throw new Error('CONTACT_EMAIL_REPLY_TOKEN_TTL_HOURS must be a positive number');
+    }
+
+    return Math.floor(Date.now() / 1000) + Math.floor(ttlHours * 3600);
+  }
+
+  private isValidPayload(value: unknown): value is EmailReplyTokenPayload {
+    if (!value || typeof value !== 'object') {
+      return false;
+    }
+
+    const candidate = value as Record<string, unknown>;
+    return (
+      typeof candidate.messageId === 'string'
+      && candidate.messageId.trim().length > 0
+      && typeof candidate.organizationId === 'string'
+      && candidate.organizationId.trim().length > 0
+      && typeof candidate.senderEmail === 'string'
+      && candidate.senderEmail.trim().length > 0
+      && typeof candidate.exp === 'number'
+      && Number.isFinite(candidate.exp)
+    );
+  }
+}

--- a/src/api/message/services/message.service.spec.ts
+++ b/src/api/message/services/message.service.spec.ts
@@ -377,6 +377,54 @@ describe('MessageService', () => {
     });
   });
 
+  it('falls back to direct payload when token is invalid but organizationId/messageId is provided', async () => {
+    const expiredToken = emailReplyTokenService.generateReplyToken({
+      messageId: '11111111-1111-4111-8111-111111111111',
+      organizationId: '22222222-2222-4222-8222-222222222222',
+      senderEmail: 'resident@example.com',
+      exp: Math.floor(Date.now() / 1000) - 30,
+    });
+    const replyTo = emailReplyTokenService.buildReplyToAddress('faleconosco@example.com', expiredToken);
+
+    jest.spyOn(messageRepository, 'findOne').mockResolvedValue({
+      id: 'msg-fallback',
+      organizationId: 'org-fallback',
+      senderEmail: 'resident@example.com',
+      senderUserId: 'resident-1',
+      senderName: 'Resident',
+      replies: [],
+    } as any);
+    jest.spyOn(messageReplyRepository, 'findOne').mockResolvedValue(null as any);
+    jest.spyOn(messageReplyRepository, 'create').mockImplementation((value) => value as any);
+    jest.spyOn(messageReplyRepository, 'save')
+      .mockResolvedValueOnce({ id: 'reply-fallback' } as any)
+      .mockResolvedValueOnce({ id: 'reply-fallback' } as any);
+    jest.spyOn(messageRepository, 'update').mockResolvedValue({} as any);
+    contactEmailSettingsService.resolveDeliveryConfig.mockResolvedValue({
+      shouldSend: false,
+      deliveryMode: 'in_app_only',
+      reason: 'Delivery mode is in_app_only',
+      validationErrors: [],
+    });
+
+    await expect(
+      service.ingestInboundEmailReply(
+        {
+          organizationId: 'org-fallback',
+          messageId: 'msg-fallback',
+          fromEmail: 'resident@example.com',
+          content: 'reply',
+          toRecipients: [replyTo],
+        } as any,
+        'expected-secret',
+      ),
+    ).resolves.toEqual({
+      created: true,
+      reason: null,
+      replyId: 'reply-fallback',
+    });
+  });
+
   it('returns sender_mismatch when reply sender does not match expected resident', async () => {
     jest.spyOn(messageRepository, 'query').mockResolvedValue([
       {

--- a/src/api/message/services/message.service.spec.ts
+++ b/src/api/message/services/message.service.spec.ts
@@ -9,6 +9,7 @@ import { EmailService } from '../../../shared/email/email.service';
 import { ContactEmailSettingsService } from './contact-email-settings.service';
 import { ForbiddenException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { EmailReplyTokenService } from './email-reply-token.service';
 
 describe('MessageService', () => {
   let service: MessageService;
@@ -18,6 +19,7 @@ describe('MessageService', () => {
   let emailService: jest.Mocked<EmailService>;
   let contactEmailSettingsService: jest.Mocked<ContactEmailSettingsService>;
   let configService: jest.Mocked<ConfigService>;
+  let emailReplyTokenService: EmailReplyTokenService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -43,9 +45,15 @@ describe('MessageService', () => {
         {
           provide: ConfigService,
           useValue: {
-            get: jest.fn(),
+            get: jest.fn((key: string) => {
+              if (key === 'CONTACT_EMAIL_INBOUND_SECRET') return 'expected-secret';
+              if (key === 'CONTACT_EMAIL_REPLY_TOKEN_SECRET') return 'token-secret';
+              if (key === 'CONTACT_EMAIL_REPLY_TOKEN_TTL_HOURS') return '720';
+              return undefined;
+            }),
           },
         },
+        EmailReplyTokenService,
       ],
     }).compile();
 
@@ -56,6 +64,7 @@ describe('MessageService', () => {
     emailService = module.get(EmailService);
     contactEmailSettingsService = module.get(ContactEmailSettingsService);
     configService = module.get(ConfigService);
+    emailReplyTokenService = module.get(EmailReplyTokenService);
   });
 
   it('skips contact email when org mode is in_app_only', async () => {
@@ -243,6 +252,187 @@ describe('MessageService', () => {
           fromEmail: 'resident@example.com',
           content: 'reply',
           externalMessageId: 'ext-1',
+        } as any,
+        'expected-secret',
+      ),
+    ).resolves.toEqual({
+      created: false,
+      reason: 'duplicate_external_message',
+      replyId: 'reply-existing',
+    });
+  });
+
+  it('resolves inbound thread by header message IDs', async () => {
+    jest.spyOn(messageRepository, 'query').mockResolvedValue([
+      {
+        messageId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+        senderEmail: 'resident@example.com',
+      },
+    ] as any);
+    jest.spyOn(messageRepository, 'findOne').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      organizationId: '22222222-2222-4222-8222-222222222222',
+      senderEmail: 'resident@example.com',
+      senderUserId: 'resident-1',
+      senderName: 'Resident',
+      replies: [],
+    } as any);
+    jest.spyOn(messageReplyRepository, 'findOne').mockResolvedValue(null as any);
+    jest.spyOn(messageReplyRepository, 'create').mockImplementation((value) => value as any);
+    jest.spyOn(messageReplyRepository, 'save')
+      .mockResolvedValueOnce({ id: 'reply-1' } as any)
+      .mockResolvedValueOnce({ id: 'reply-1' } as any);
+    jest.spyOn(messageRepository, 'update').mockResolvedValue({} as any);
+    contactEmailSettingsService.resolveDeliveryConfig.mockResolvedValue({
+      shouldSend: false,
+      deliveryMode: 'in_app_only',
+      reason: 'Delivery mode is in_app_only',
+      validationErrors: [],
+    });
+
+    await expect(
+      service.ingestInboundEmailReply(
+        {
+          fromEmail: 'resident@example.com',
+          content: 'reply',
+          threadMessageIds: ['<ADMIN-ROOT@example.com>'],
+        } as any,
+        'expected-secret',
+      ),
+    ).resolves.toEqual({
+      created: true,
+      reason: null,
+      replyId: 'reply-1',
+    });
+  });
+
+  it('resolves inbound thread by signed plus-address token', async () => {
+    const token = emailReplyTokenService.generateReplyToken({
+      messageId: '11111111-1111-4111-8111-111111111111',
+      organizationId: '22222222-2222-4222-8222-222222222222',
+      senderEmail: 'resident@example.com',
+    });
+    const replyTo = emailReplyTokenService.buildReplyToAddress('faleconosco@example.com', token);
+
+    jest.spyOn(messageRepository, 'findOne').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      organizationId: '22222222-2222-4222-8222-222222222222',
+      senderEmail: 'resident@example.com',
+      senderUserId: 'resident-1',
+      senderName: 'Resident',
+      replies: [],
+    } as any);
+    jest.spyOn(messageReplyRepository, 'findOne').mockResolvedValue(null as any);
+    jest.spyOn(messageReplyRepository, 'create').mockImplementation((value) => value as any);
+    jest.spyOn(messageReplyRepository, 'save')
+      .mockResolvedValueOnce({ id: 'reply-2' } as any)
+      .mockResolvedValueOnce({ id: 'reply-2' } as any);
+    jest.spyOn(messageRepository, 'update').mockResolvedValue({} as any);
+    contactEmailSettingsService.resolveDeliveryConfig.mockResolvedValue({
+      shouldSend: false,
+      deliveryMode: 'in_app_only',
+      reason: 'Delivery mode is in_app_only',
+      validationErrors: [],
+    });
+
+    await expect(
+      service.ingestInboundEmailReply(
+        {
+          fromEmail: 'resident@example.com',
+          content: 'reply',
+          toRecipients: [replyTo],
+        } as any,
+        'expected-secret',
+      ),
+    ).resolves.toEqual({
+      created: true,
+      reason: null,
+      replyId: 'reply-2',
+    });
+  });
+
+  it('returns invalid_reply_token when plus token is expired', async () => {
+    const expiredToken = emailReplyTokenService.generateReplyToken({
+      messageId: '11111111-1111-4111-8111-111111111111',
+      organizationId: '22222222-2222-4222-8222-222222222222',
+      senderEmail: 'resident@example.com',
+      exp: Math.floor(Date.now() / 1000) - 30,
+    });
+    const replyTo = emailReplyTokenService.buildReplyToAddress('faleconosco@example.com', expiredToken);
+
+    await expect(
+      service.ingestInboundEmailReply(
+        {
+          fromEmail: 'resident@example.com',
+          content: 'reply',
+          deliveredToRecipients: [replyTo],
+        } as any,
+        'expected-secret',
+      ),
+    ).resolves.toEqual({
+      created: false,
+      reason: 'invalid_reply_token',
+      replyId: null,
+    });
+  });
+
+  it('returns sender_mismatch when reply sender does not match expected resident', async () => {
+    jest.spyOn(messageRepository, 'query').mockResolvedValue([
+      {
+        messageId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+        senderEmail: 'resident@example.com',
+      },
+    ] as any);
+    jest.spyOn(messageRepository, 'findOne').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      organizationId: '22222222-2222-4222-8222-222222222222',
+      senderEmail: 'resident@example.com',
+      senderUserId: 'resident-1',
+      senderName: 'Resident',
+      replies: [],
+    } as any);
+
+    await expect(
+      service.ingestInboundEmailReply(
+        {
+          fromEmail: 'another-resident@example.com',
+          content: 'reply',
+          threadMessageIds: ['<admin-root@example.com>'],
+        } as any,
+        'expected-secret',
+      ),
+    ).resolves.toEqual({
+      created: false,
+      reason: 'sender_mismatch',
+      replyId: null,
+    });
+  });
+
+  it('handles duplicate key races atomically when saving inbound reply', async () => {
+    jest.spyOn(messageRepository, 'findOne').mockResolvedValue({
+      id: 'msg-atomic',
+      organizationId: 'org-atomic',
+      senderEmail: 'resident@example.com',
+      senderUserId: 'resident-1',
+      senderName: 'Resident',
+      replies: [],
+    } as any);
+    jest.spyOn(messageReplyRepository, 'findOne')
+      .mockResolvedValueOnce(null as any)
+      .mockResolvedValueOnce({ id: 'reply-existing' } as any);
+    jest.spyOn(messageReplyRepository, 'create').mockImplementation((value) => value as any);
+    jest.spyOn(messageReplyRepository, 'save').mockRejectedValueOnce({ code: '23505' });
+
+    await expect(
+      service.ingestInboundEmailReply(
+        {
+          organizationId: 'org-atomic',
+          messageId: 'msg-atomic',
+          fromEmail: 'resident@example.com',
+          content: 'reply',
+          externalMessageId: 'ext-race-1',
         } as any,
         'expected-secret',
       ),

--- a/src/api/message/services/message.service.ts
+++ b/src/api/message/services/message.service.ts
@@ -11,10 +11,18 @@ import { Message, MessageEmailDeliveryStatus } from '../entities/message.entity'
 import { MessageReply } from '../entities/message-reply.entity';
 import { ContactEmailSettingsService } from './contact-email-settings.service';
 import { IngestInboundEmailReplyDto } from '../dto/ingest-inbound-email-reply.dto';
+import { EmailReplyTokenService } from './email-reply-token.service';
 
 interface MessageUnreadState {
   unreadCount: number;
   hasUnread: boolean;
+}
+
+interface ResolvedInboundThread {
+  messageId: string;
+  organizationId: string;
+  expectedSenderEmail: string | null;
+  resolutionMethod: 'header' | 'reply_token' | 'direct_payload';
 }
 
 @Injectable()
@@ -31,6 +39,7 @@ export class MessageService {
     private readonly emailService: EmailService,
     private readonly contactEmailSettingsService: ContactEmailSettingsService,
     private readonly configService: ConfigService,
+    private readonly emailReplyTokenService: EmailReplyTokenService,
   ) {}
 
   async createFromContact(
@@ -374,20 +383,37 @@ export class MessageService {
       throw new ForbiddenException('Invalid inbound email secret');
     }
 
+    const normalizedFrom = data.fromEmail.trim().toLowerCase();
+    const resolvedThread = await this.resolveInboundThread(data);
+    if (!resolvedThread) {
+      return { created: false, reason: 'thread_not_found', replyId: null };
+    }
+    if (resolvedThread === 'invalid_reply_token') {
+      return { created: false, reason: 'invalid_reply_token', replyId: null };
+    }
+
     const message = await this.messageRepository.findOne({
       where: {
-        id: data.messageId,
-        organizationId: data.organizationId,
+        id: resolvedThread.messageId,
+        organizationId: resolvedThread.organizationId,
       },
     });
 
     if (!message) {
-      return { created: false, reason: 'message_not_found', replyId: null };
+      return { created: false, reason: 'thread_not_found', replyId: null };
     }
 
-    const normalizedFrom = data.fromEmail.trim().toLowerCase();
-    const normalizedSender = (message.senderEmail || '').trim().toLowerCase();
-    if (!normalizedSender || normalizedFrom !== normalizedSender) {
+    const normalizedMessageSender = (message.senderEmail || '').trim().toLowerCase();
+    if (
+      resolvedThread.expectedSenderEmail
+      && normalizedMessageSender
+      && resolvedThread.expectedSenderEmail !== normalizedMessageSender
+    ) {
+      return { created: false, reason: 'invalid_reply_token', replyId: null };
+    }
+
+    const expectedSenderEmail = resolvedThread.expectedSenderEmail || normalizedMessageSender;
+    if (!expectedSenderEmail || normalizedFrom !== expectedSenderEmail) {
       return { created: false, reason: 'sender_mismatch', replyId: null };
     }
 
@@ -488,7 +514,7 @@ export class MessageService {
       subject: `[Resposta] ${message.subject}`,
       text: this.composeResidentReplyEmail(message, reply),
       from: config.from || undefined,
-      replyTo: config.replyTo || undefined,
+      replyTo: this.buildSignedReplyToAddress(message, config.replyTo, config.smtp?.from),
       inReplyTo: residentThreadLatest || undefined,
       references: this.composeReferences(residentThreadRoot, residentThreadLatest),
       headers: {
@@ -531,7 +557,7 @@ export class MessageService {
       subject: `[Contato][Resposta Morador] ${message.subject}`,
       text: this.composeAdminResidentReplyEmail(message, reply),
       from: config.from || undefined,
-      replyTo: config.replyTo || undefined,
+      replyTo: this.buildSignedReplyToAddress(message, config.replyTo, config.smtp?.from),
       inReplyTo: adminThreadLatest || adminThreadRoot || undefined,
       references: this.composeReferences(adminThreadRoot, adminThreadLatest),
       headers: {
@@ -576,7 +602,7 @@ export class MessageService {
         to: config.recipients,
         from: config.from || undefined,
         subject: `[Contato] ${this.categoryLabel(message.category)} - ${message.subject}`,
-        replyTo: config.replyTo || undefined,
+        replyTo: this.buildSignedReplyToAddress(message, config.replyTo, config.smtp?.from),
         text: this.composeAdminMessageEmail(message),
         headers: {
           'X-GrillRent-Message-Id': message.id,
@@ -610,6 +636,182 @@ export class MessageService {
         deliveryMode: 'in_app_and_email',
         reason,
       };
+    }
+  }
+
+  private async resolveInboundThread(
+    data: IngestInboundEmailReplyDto,
+  ): Promise<ResolvedInboundThread | 'invalid_reply_token' | null> {
+    const threadMessageIds = this.normalizeProviderMessageIds(data.threadMessageIds || []);
+    if (threadMessageIds.length) {
+      const headerMatch = await this.resolveMessageThreadByProviderIds(threadMessageIds);
+      if (headerMatch) {
+        return {
+          ...headerMatch,
+          resolutionMethod: 'header',
+        };
+      }
+    }
+
+    const replyTokenResult = this.resolveThreadByReplyToken(data);
+    if (replyTokenResult === 'invalid_reply_token') {
+      return 'invalid_reply_token';
+    }
+    if (replyTokenResult) {
+      return replyTokenResult;
+    }
+
+    if (data.organizationId && data.messageId) {
+      return {
+        organizationId: data.organizationId,
+        messageId: data.messageId,
+        expectedSenderEmail: null,
+        resolutionMethod: 'direct_payload',
+      };
+    }
+
+    return null;
+  }
+
+  private resolveThreadByReplyToken(
+    data: IngestInboundEmailReplyDto,
+  ): ResolvedInboundThread | 'invalid_reply_token' | null {
+    const tokenCandidates = this.collectReplyTokenCandidates(data);
+    if (!tokenCandidates.length) {
+      return null;
+    }
+
+    let sawInvalidToken = false;
+    for (const token of tokenCandidates) {
+      const verification = this.emailReplyTokenService.verifyReplyToken(token);
+      if (!verification.valid) {
+        sawInvalidToken = true;
+        continue;
+      }
+
+      return {
+        messageId: verification.payload.messageId,
+        organizationId: verification.payload.organizationId,
+        expectedSenderEmail: verification.payload.senderEmail,
+        resolutionMethod: 'reply_token',
+      };
+    }
+
+    return sawInvalidToken ? 'invalid_reply_token' : null;
+  }
+
+  private collectReplyTokenCandidates(data: IngestInboundEmailReplyDto): string[] {
+    const allRecipients = [
+      ...(data.toRecipients || []),
+      ...(data.deliveredToRecipients || []),
+      ...(data.xOriginalToRecipients || []),
+    ];
+
+    const extractedTokens = allRecipients
+      .map((recipient) => this.emailReplyTokenService.extractTokenFromReplyAddress(recipient))
+      .filter((value): value is string => Boolean(value && value.trim()));
+
+    return Array.from(new Set(extractedTokens));
+  }
+
+  private async resolveMessageThreadByProviderIds(providerIds: string[]): Promise<ResolvedInboundThread | null> {
+    if (!providerIds.length) {
+      return null;
+    }
+
+    const rows = await this.messageRepository.query(
+      `
+        with normalized_candidates as (
+          select unnest($1::text[]) as candidate
+        ),
+        direct_match as (
+          select
+            m.id as "messageId",
+            m."organizationId" as "organizationId",
+            m."senderEmail" as "senderEmail",
+            1 as priority
+          from message m
+          join normalized_candidates c
+            on regexp_replace(lower(coalesce(m."adminEmailProviderMessageId", '')), '[<>]', '', 'g') = c.candidate
+        ),
+        reply_match as (
+          select
+            m.id as "messageId",
+            m."organizationId" as "organizationId",
+            m."senderEmail" as "senderEmail",
+            2 as priority
+          from message_reply mr
+          join message m on m.id = mr."messageId"
+          join normalized_candidates c
+            on regexp_replace(lower(coalesce(mr."emailProviderMessageId", '')), '[<>]', '', 'g') = c.candidate
+        )
+        select "messageId", "organizationId", "senderEmail"
+        from (
+          select * from direct_match
+          union all
+          select * from reply_match
+        ) matches
+        order by priority asc
+        limit 1
+      `,
+      [providerIds],
+    );
+
+    const match = rows?.[0];
+    if (!match?.messageId || !match?.organizationId) {
+      return null;
+    }
+
+    return {
+      messageId: match.messageId,
+      organizationId: match.organizationId,
+      expectedSenderEmail: match.senderEmail ? String(match.senderEmail).trim().toLowerCase() : null,
+      resolutionMethod: 'header',
+    };
+  }
+
+  private normalizeProviderMessageIds(values: string[]): string[] {
+    const normalized = values
+      .map((value) => value.trim().toLowerCase().replace(/^<+|>+$/g, ''))
+      .filter(Boolean);
+
+    return Array.from(new Set(normalized));
+  }
+
+  private buildSignedReplyToAddress(
+    message: Message,
+    configuredReplyTo: string | null,
+    smtpFrom?: string | null,
+  ): string | undefined {
+    const configuredReply = configuredReplyTo?.trim().toLowerCase() || null;
+    const configuredSmtpFrom = smtpFrom?.trim().toLowerCase() || null;
+    const envMailbox = (this.configService.get<string>('CONTACT_EMAIL_REPLY_BASE_ADDRESS') || '').trim().toLowerCase();
+    const replyMailbox = envMailbox || configuredSmtpFrom || configuredReply;
+
+    if (!replyMailbox) {
+      return configuredReply || undefined;
+    }
+    if (!message.organizationId || !message.senderEmail) {
+      return configuredReply || undefined;
+    }
+
+    try {
+      const token = this.emailReplyTokenService.generateReplyToken({
+        messageId: message.id,
+        organizationId: message.organizationId,
+        senderEmail: message.senderEmail,
+      });
+      return this.emailReplyTokenService.buildReplyToAddress(replyMailbox, token);
+    } catch (error) {
+      this.logger.warn(
+        JSON.stringify({
+          event: 'reply_token_generation_failed',
+          messageId: message.id,
+          organizationId: message.organizationId || null,
+          reason: error instanceof Error ? this.trimError(error.message) : 'unknown_error',
+        }),
+      );
+      return configuredReply || undefined;
     }
   }
 

--- a/src/api/message/services/message.service.ts
+++ b/src/api/message/services/message.service.ts
@@ -514,7 +514,7 @@ export class MessageService {
       subject: `[Resposta] ${message.subject}`,
       text: this.composeResidentReplyEmail(message, reply),
       from: config.from || undefined,
-      replyTo: this.buildSignedReplyToAddress(message, config.replyTo, config.smtp?.from),
+      replyTo: this.buildSignedReplyToAddress(message, config.replyTo),
       inReplyTo: residentThreadLatest || undefined,
       references: this.composeReferences(residentThreadRoot, residentThreadLatest),
       headers: {
@@ -557,7 +557,7 @@ export class MessageService {
       subject: `[Contato][Resposta Morador] ${message.subject}`,
       text: this.composeAdminResidentReplyEmail(message, reply),
       from: config.from || undefined,
-      replyTo: this.buildSignedReplyToAddress(message, config.replyTo, config.smtp?.from),
+      replyTo: this.buildSignedReplyToAddress(message, config.replyTo),
       inReplyTo: adminThreadLatest || adminThreadRoot || undefined,
       references: this.composeReferences(adminThreadRoot, adminThreadLatest),
       headers: {
@@ -602,7 +602,7 @@ export class MessageService {
         to: config.recipients,
         from: config.from || undefined,
         subject: `[Contato] ${this.categoryLabel(message.category)} - ${message.subject}`,
-        replyTo: this.buildSignedReplyToAddress(message, config.replyTo, config.smtp?.from),
+        replyTo: this.buildSignedReplyToAddress(message, config.replyTo),
         text: this.composeAdminMessageEmail(message),
         headers: {
           'X-GrillRent-Message-Id': message.id,
@@ -653,15 +653,17 @@ export class MessageService {
       }
     }
 
-    const replyTokenResult = this.resolveThreadByReplyToken(data);
+    const hasDirectPayload = Boolean(data.organizationId && data.messageId);
+    const replyTokenResult = await this.resolveThreadByReplyToken(data);
     if (replyTokenResult === 'invalid_reply_token') {
-      return 'invalid_reply_token';
-    }
-    if (replyTokenResult) {
+      if (!hasDirectPayload) {
+        return 'invalid_reply_token';
+      }
+    } else if (replyTokenResult) {
       return replyTokenResult;
     }
 
-    if (data.organizationId && data.messageId) {
+    if (hasDirectPayload && data.organizationId && data.messageId) {
       return {
         organizationId: data.organizationId,
         messageId: data.messageId,
@@ -673,9 +675,9 @@ export class MessageService {
     return null;
   }
 
-  private resolveThreadByReplyToken(
+  private async resolveThreadByReplyToken(
     data: IngestInboundEmailReplyDto,
-  ): ResolvedInboundThread | 'invalid_reply_token' | null {
+  ): Promise<ResolvedInboundThread | 'invalid_reply_token' | null> {
     const tokenCandidates = this.collectReplyTokenCandidates(data);
     if (!tokenCandidates.length) {
       return null;
@@ -683,16 +685,41 @@ export class MessageService {
 
     let sawInvalidToken = false;
     for (const token of tokenCandidates) {
-      const verification = this.emailReplyTokenService.verifyReplyToken(token);
-      if (!verification.valid) {
+      const decoded = this.emailReplyTokenService.verifyReplyToken(token);
+      if (!decoded.valid) {
+        sawInvalidToken = true;
+        continue;
+      }
+
+      if (decoded.payload.organizationId && decoded.payload.senderEmail) {
+        return {
+          messageId: decoded.payload.messageId,
+          organizationId: decoded.payload.organizationId,
+          expectedSenderEmail: decoded.payload.senderEmail,
+          resolutionMethod: 'reply_token',
+        };
+      }
+
+      const message = await this.messageRepository.findOne({
+        where: { id: decoded.payload.messageId },
+      });
+      if (!message?.organizationId || !message.senderEmail) {
+        continue;
+      }
+
+      const verified = this.emailReplyTokenService.verifyCompactTokenAgainstContext(token, {
+        organizationId: message.organizationId,
+        senderEmail: message.senderEmail,
+      });
+      if (!verified.valid) {
         sawInvalidToken = true;
         continue;
       }
 
       return {
-        messageId: verification.payload.messageId,
-        organizationId: verification.payload.organizationId,
-        expectedSenderEmail: verification.payload.senderEmail,
+        messageId: message.id,
+        organizationId: message.organizationId,
+        expectedSenderEmail: message.senderEmail.trim().toLowerCase(),
         resolutionMethod: 'reply_token',
       };
     }
@@ -781,14 +808,10 @@ export class MessageService {
   private buildSignedReplyToAddress(
     message: Message,
     configuredReplyTo: string | null,
-    smtpFrom?: string | null,
   ): string | undefined {
     const configuredReply = configuredReplyTo?.trim().toLowerCase() || null;
-    const configuredSmtpFrom = smtpFrom?.trim().toLowerCase() || null;
     const envMailbox = (this.configService.get<string>('CONTACT_EMAIL_REPLY_BASE_ADDRESS') || '').trim().toLowerCase();
-    const replyMailbox = envMailbox || configuredSmtpFrom || configuredReply;
-
-    if (!replyMailbox) {
+    if (!envMailbox) {
       return configuredReply || undefined;
     }
     if (!message.organizationId || !message.senderEmail) {
@@ -801,7 +824,7 @@ export class MessageService {
         organizationId: message.organizationId,
         senderEmail: message.senderEmail,
       });
-      return this.emailReplyTokenService.buildReplyToAddress(replyMailbox, token);
+      return this.emailReplyTokenService.buildReplyToAddress(envMailbox, token);
     } catch (error) {
       this.logger.warn(
         JSON.stringify({


### PR DESCRIPTION
This pull request introduces support for inbound email reply threading, allowing users to reply to messages via email and have those replies correctly associated with the original conversation. The implementation includes secure token-based threading using plus-addressing, robust validation, and comprehensive test coverage. It also updates configuration and documentation to support these new features.

**Inbound Email Reply Threading and Token Validation**

* Added a new `EmailReplyTokenService` to generate and verify HMAC-SHA256 signed tokens for secure plus-address reply threading, including token expiration and sender validation. [[1]](diffhunk://#diff-06143e5f8782289a98f3777138a9e9675eaffbbc0fbb625f7ced6562174b6f69R1-R161) [[2]](diffhunk://#diff-4d0b05df707328cdff241977ea0163287d4d871379a6d72bbf6cc76be28c7581R1-R71)
* Updated the `MessageService` to resolve inbound email threads both by email headers (`In-Reply-To`, `References`) and by signed tokens in plus-addresses, with explicit error reasons for invalid or mismatched replies. [[1]](diffhunk://#diff-9092bdddc632e49183cbfd87f0f0a2718dcb356cce8c5447c8403be2483316d9R14-R27) [[2]](diffhunk://#diff-9092bdddc632e49183cbfd87f0f0a2718dcb356cce8c5447c8403be2483316d9R42) [[3]](diffhunk://#diff-76c0001ee4b3265ce7e352428b7e0f28663b710f918bb098dd22ce040fbfad97R12) [[4]](diffhunk://#diff-76c0001ee4b3265ce7e352428b7e0f28663b710f918bb098dd22ce040fbfad97R22) [[5]](diffhunk://#diff-76c0001ee4b3265ce7e352428b7e0f28663b710f918bb098dd22ce040fbfad97L46-R56) [[6]](diffhunk://#diff-76c0001ee4b3265ce7e352428b7e0f28663b710f918bb098dd22ce040fbfad97R67) [[7]](diffhunk://#diff-76c0001ee4b3265ce7e352428b7e0f28663b710f918bb098dd22ce040fbfad97R264-R444)

**DTO and Validation Enhancements**

* Enhanced the `IngestInboundEmailReplyDto` and its validation schema to support new fields required for threading (e.g., `threadMessageIds`, `toRecipients`, `deliveredToRecipients`, `xOriginalToRecipients`), and made `organizationId` and `messageId` optional to support header/token-based resolution.

**Configuration and Documentation**

* Added new environment variables to `.env.example` for configuring inbound email reply secrets, token secrets, TTL, and base reply address.
* Updated `README.md` with documentation on the new inbound email reply endpoint, threading strategy, security, and explicit error reasons.

**Module Wiring**

* Registered `EmailReplyTokenService` as a provider and export in `MessageModule` for dependency injection.

These changes collectively enable robust, secure, and user-friendly inbound email reply threading for the messaging system.…d threading and validation