### PR TITLE
Enhance email reply token format and verification logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ npm run test:cov
 
 - Estratégia de resolução:
   1. `In-Reply-To` / `References` (IDs de thread do provider).
-  2. Fallback por token assinado em `Reply-To` no formato `faleconosco+grillrent.<token>@dominio`.
+  2. Fallback por token assinado em `Reply-To` no formato `faleconosco+gr.<token>@dominio` (compatível com legado `+grillrent.<token>`).
 - Segurança:
   - Token HMAC-SHA256 com `CONTACT_EMAIL_REPLY_TOKEN_SECRET`.
   - Expiração via `CONTACT_EMAIL_REPLY_TOKEN_TTL_HOURS` (ex: `720`).

--- a/src/api/message/services/email-reply-token.service.spec.ts
+++ b/src/api/message/services/email-reply-token.service.spec.ts
@@ -50,7 +50,9 @@ describe('EmailReplyTokenService', () => {
       senderEmail,
     });
 
-    const tampered = `${token.slice(0, -1)}x`;
+    const tamperedBytes = Buffer.from(token, 'base64url');
+    tamperedBytes[0] = tamperedBytes[0] ^ 0xff;
+    const tampered = tamperedBytes.toString('base64url');
     const verification = service.verifyCompactTokenAgainstContext(tampered, {
       organizationId,
       senderEmail,
@@ -78,8 +80,19 @@ describe('EmailReplyTokenService', () => {
     });
     const replyAddress = service.buildReplyToAddress('faleconosco@example.com', token);
 
-    expect(replyAddress.startsWith('faleconosco+grillrent.')).toBe(true);
+    expect(replyAddress.startsWith('faleconosco+gr.')).toBe(true);
     expect(service.extractTokenFromReplyAddress(replyAddress)).toBe(token);
     expect(service.extractTokenFromReplyAddress(`"Contact" <${replyAddress}>`)).toBe(token);
+  });
+
+  it('accepts legacy +grillrent token format for backward compatibility', () => {
+    const token = service.generateReplyToken({
+      messageId: '11111111-1111-4111-8111-111111111111',
+      organizationId: '22222222-2222-4222-8222-222222222222',
+      senderEmail: 'resident@example.com',
+    });
+
+    const legacyAddress = `faleconosco+grillrent.${token}@example.com`;
+    expect(service.extractTokenFromReplyAddress(legacyAddress)).toBe(token);
   });
 });

--- a/src/api/message/services/email-reply-token.service.ts
+++ b/src/api/message/services/email-reply-token.service.ts
@@ -5,6 +5,7 @@ import { createHmac, timingSafeEqual } from 'crypto';
 const DEFAULT_TTL_HOURS = 720;
 const COMPACT_TOKEN_MAC_BYTES_LENGTH = 10;
 const COMPACT_TOKEN_BYTES_LENGTH = 16 + 4 + COMPACT_TOKEN_MAC_BYTES_LENGTH;
+const SHORT_PLUS_TAG = 'gr';
 
 export interface EmailReplyTokenPayload {
   messageId: string;
@@ -117,7 +118,7 @@ export class EmailReplyTokenService {
       throw new Error('Invalid reply mailbox address');
     }
 
-    const plusLocalPart = `${localPart}+grillrent.${token}`;
+    const plusLocalPart = `${localPart}+${SHORT_PLUS_TAG}.${token}`;
     if (plusLocalPart.length > 64) {
       throw new Error('Reply token local-part exceeds 64 characters');
     }
@@ -141,7 +142,7 @@ export class EmailReplyTokenService {
       return null;
     }
 
-    const match = localPart.match(/\+grillrent\.([A-Za-z0-9._-]+)$/i);
+    const match = localPart.match(/\+(?:gr|grillrent)\.([A-Za-z0-9._-]+)$/i);
     if (!match?.[1]) {
       return null;
     }


### PR DESCRIPTION
This pull request updates the reply-to token email address format to use a shorter, more generic tag while maintaining backward compatibility with the legacy format. It also improves test coverage and robustness for token tampering scenarios.

**Email reply-to address format and compatibility:**

* Changed the reply-to address format from `+grillrent.<token>` to `+gr.<token>`, and updated the regular expression to accept both the new and legacy formats for backward compatibility (`src/api/message/services/email-reply-token.service.ts`). [[1]](diffhunk://#diff-06143e5f8782289a98f3777138a9e9675eaffbbc0fbb625f7ced6562174b6f69L120-R121) [[2]](diffhunk://#diff-06143e5f8782289a98f3777138a9e9675eaffbbc0fbb625f7ced6562174b6f69L144-R145)
* Defined a constant `SHORT_PLUS_TAG` for the new short tag `gr` to simplify future updates (`src/api/message/services/email-reply-token.service.ts`).
* Updated documentation to clarify that the new format is compatible with the legacy `+grillrent.<token>` format (`README.md`).

**Testing improvements:**

* Enhanced tests to verify that both the new and legacy reply-to address formats are accepted, ensuring backward compatibility (`src/api/message/services/email-reply-token.service.spec.ts`).
* Improved token tampering tests by mutating the token at the byte level for more robust verification (`src/api/message/services/email-reply-token.service.spec.ts`).…verification logic