### PR TITLE
test(email): clear Resend mock before each test

### DIFF
--- a/src/shared/email/email.service.spec.ts
+++ b/src/shared/email/email.service.spec.ts
@@ -18,6 +18,7 @@ describe('EmailService', () => {
       get: jest.fn((key: string) => configValues[key]),
     } as unknown as ConfigService;
 
+    (Resend as unknown as jest.Mock).mockClear();
     (Resend as unknown as jest.Mock).mockImplementation(() => ({
       emails: {
         send: mockResendSend,


### PR DESCRIPTION
This pull request makes a minor adjustment to the test setup for the `EmailService` by clearing the `Resend` mock before each test run. This ensures that previous mock state does not affect subsequent tests.

- Test reliability improvement:
  * [`src/shared/email/email.service.spec.ts`](diffhunk://#diff-4472a3884e2fa16fc4936109bf7f44d5c74ff68c2ce0230b6bab396f354cd79eR21): Added a call to `mockClear()` on the `Resend` mock to reset its state before each test.