### PR TITLE
Add booking deletion before user removal and update imports

### DIFF
--- a/src/api/user/services/user.service.spec.ts
+++ b/src/api/user/services/user.service.spec.ts
@@ -9,10 +9,12 @@ import { Organization } from '../../organization/entities/organization.entity';
 import { OrganizationContactEmailSettings } from '../../message/entities/organization-contact-email-settings.entity';
 import { EmailService } from '../../../shared/email/email.service';
 import { ConfigService } from '@nestjs/config';
+import { Booking } from '../../booking/entities/booking.entity';
 
 describe('UserService', () => {
   let service: UserService;
   let userRepository: jest.Mocked<Repository<User>>;
+  let bookingRepository: jest.Mocked<Repository<Booking>>;
   let organizationRepository: jest.Mocked<Repository<Organization>>;
   let organizationContactEmailSettingsRepository: jest.Mocked<Repository<OrganizationContactEmailSettings>>;
   let emailService: jest.Mocked<EmailService>;
@@ -28,6 +30,13 @@ describe('UserService', () => {
             findOne: jest.fn(),
             save: jest.fn(),
             createQueryBuilder: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(Booking),
+          useValue: {
+            delete: jest.fn(),
           },
         },
         {
@@ -64,6 +73,7 @@ describe('UserService', () => {
 
     service = module.get(UserService);
     userRepository = module.get(getRepositoryToken(User));
+    bookingRepository = module.get(getRepositoryToken(Booking));
     organizationRepository = module.get(getRepositoryToken(Organization));
     organizationContactEmailSettingsRepository = module.get(getRepositoryToken(OrganizationContactEmailSettings));
     emailService = module.get(EmailService);
@@ -380,5 +390,30 @@ describe('UserService', () => {
       message: 'First access tour reset successfully',
       tour: { firstAccessTourVersionCompleted: null },
     });
+  });
+
+  it('deletes user bookings before deleting user', async () => {
+    userRepository.findOne.mockResolvedValue({
+      id: 'user-1',
+      organizationId: 'org-1',
+      role: UserRole.RESIDENT,
+    } as User);
+    userRepository.remove.mockResolvedValue({ id: 'user-1' } as User);
+
+    const result = await service.remove('user-1', 'org-1');
+
+    expect(bookingRepository.delete).toHaveBeenCalledWith({ userId: 'user-1', organizationId: 'org-1' });
+    expect(userRepository.remove).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'user-1', organizationId: 'org-1' }),
+    );
+    expect(result).toEqual({ message: 'User removed successfully' });
+  });
+
+  it('throws not found when deleting a missing user', async () => {
+    userRepository.findOne.mockResolvedValue(null);
+
+    await expect(service.remove('missing-user', 'org-1')).rejects.toThrow('User not found');
+    expect(bookingRepository.delete).not.toHaveBeenCalled();
+    expect(userRepository.remove).not.toHaveBeenCalled();
   });
 });

--- a/src/api/user/services/user.service.spec.ts
+++ b/src/api/user/services/user.service.spec.ts
@@ -406,6 +406,9 @@ describe('UserService', () => {
     expect(userRepository.remove).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'user-1', organizationId: 'org-1' }),
     );
+    const deleteCallOrder = (bookingRepository.delete as jest.Mock).mock.invocationCallOrder[0];
+    const removeCallOrder = (userRepository.remove as jest.Mock).mock.invocationCallOrder[0];
+    expect(deleteCallOrder).toBeLessThan(removeCallOrder);
     expect(result).toEqual({ message: 'User removed successfully' });
   });
 

--- a/src/api/user/services/user.service.ts
+++ b/src/api/user/services/user.service.ts
@@ -28,6 +28,7 @@ import { EmailService, type SendEmailResult } from '../../../shared/email/email.
 import { Organization } from '../../organization/entities/organization.entity';
 import { OrganizationContactEmailSettings } from '../../message/entities/organization-contact-email-settings.entity';
 import { composeFromHeader, isValidEmailAddress, normalizeEmailAddress } from '../../../shared/email/email-address.util';
+import { Booking } from '../../booking/entities/booking.entity';
 
 @Injectable()
 export class UserService {
@@ -38,6 +39,8 @@ export class UserService {
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+    @InjectRepository(Booking)
+    private readonly bookingRepository: Repository<Booking>,
     @InjectRepository(Organization)
     private readonly organizationRepository: Repository<Organization>,
     @InjectRepository(OrganizationContactEmailSettings)
@@ -167,6 +170,7 @@ export class UserService {
       this.logger.warn(`User not found: ${userId}`);
       throw new NotFoundException('User not found');
     }
+    await this.bookingRepository.delete({ userId, organizationId });
     await this.userRepository.remove(user);
     this.logger.log(`User removed successfully: ${userId}`);
     return { message: 'User removed successfully' };

--- a/src/api/user/services/user.service.ts
+++ b/src/api/user/services/user.service.ts
@@ -170,8 +170,11 @@ export class UserService {
       this.logger.warn(`User not found: ${userId}`);
       throw new NotFoundException('User not found');
     }
-    await this.bookingRepository.delete({ userId, organizationId });
-    await this.userRepository.remove(user);
+
+    await this.userRepository.manager.transaction(async (transactionalEntityManager) => {
+      await transactionalEntityManager.delete(Booking, { userId, organizationId });
+      await transactionalEntityManager.remove(user);
+    });
     this.logger.log(`User removed successfully: ${userId}`);
     return { message: 'User removed successfully' };
   }

--- a/src/api/user/user.module.ts
+++ b/src/api/user/user.module.ts
@@ -13,10 +13,11 @@ import { JwtAuthGuard } from '../../shared/auth/guards/jwt-auth.guard';
 import { Organization } from '../organization/entities/organization.entity';
 import { OrganizationContactEmailSettings } from '../message/entities/organization-contact-email-settings.entity';
 import { EmailModule } from '../../shared/email/email.module';
+import { Booking } from '../booking/entities/booking.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, RevokedToken, Organization, OrganizationContactEmailSettings]),
+    TypeOrmModule.forFeature([User, Booking, RevokedToken, Organization, OrganizationContactEmailSettings]),
     PassportModule,
     EmailModule,
     JwtModule.registerAsync({


### PR DESCRIPTION
This pull request updates the user deletion logic to ensure that all bookings associated with a user are deleted before the user itself is removed. It also adds new tests to verify this behavior and updates the relevant module and service to support these changes.

**User deletion and booking cleanup:**

* The `UserService.remove` method now deletes all `Booking` records for a user within an organization before removing the user, ensuring no orphaned bookings remain.
* The `Booking` entity is injected into the `UserService` and included in the module's TypeORM feature imports to enable booking deletion. [[1]](diffhunk://#diff-80b0379135987ebe65eedb18df3a35c99d9ac724efe8333150e8cacf9eae6f54R31) [[2]](diffhunk://#diff-80b0379135987ebe65eedb18df3a35c99d9ac724efe8333150e8cacf9eae6f54R42-R43) [[3]](diffhunk://#diff-e099b54cbb24460de9769007fad8a717b1fc5b973fc247a58e250ac47ee88d25R16-R20)

**Testing improvements:**

* Added tests to verify that bookings are deleted before the user is removed, and that attempting to delete a non-existent user throws a "User not found" error and does not attempt to delete bookings or the user.
* Updated the test setup to mock the `Booking` repository and ensure it is available for tests. [[1]](diffhunk://#diff-19b1b7b70ba056e252fa89d1f289d75d23fadbdc5fe6f9632b60144fb4437902R12-R17) [[2]](diffhunk://#diff-19b1b7b70ba056e252fa89d1f289d75d23fadbdc5fe6f9632b60144fb4437902R33-R39) [[3]](diffhunk://#diff-19b1b7b70ba056e252fa89d1f289d75d23fadbdc5fe6f9632b60144fb4437902R76)